### PR TITLE
The browser pin feature seems to slow down PhantomJS

### DIFF
--- a/canopy/canopy.fs
+++ b/canopy/canopy.fs
@@ -545,6 +545,7 @@ let start b =
         | FirefoxWithProfile profile -> 
             new OpenQA.Selenium.Firefox.FirefoxDriver(profile) :> IWebDriver
         | PhantomJS -> 
+            autoPinBrowserRightOnLaunch <- false
             new OpenQA.Selenium.PhantomJS.PhantomJSDriver(phantomJSDir) :> IWebDriver
 
     if autoPinBrowserRightOnLaunch = true then pin Right


### PR DESCRIPTION
This pinning seems to slow down PhantomJS by about 3-4 seconds per run. A headless browser doesn't need pinning anyhow.
