### PR TITLE
Convert canopy to use sizzle selector engine instead of normal WebDriver...

### DIFF
--- a/canopy/canopy.fs
+++ b/canopy/canopy.fs
@@ -5,6 +5,7 @@ open OpenQA.Selenium.Firefox
 open OpenQA.Selenium
 open OpenQA.Selenium.Support.UI
 open OpenQA.Selenium.Interactions
+open SizSelCsZzz
 open Microsoft.FSharp.Core.Printf
 open System.IO
 open System
@@ -143,7 +144,7 @@ let waitFor (f : unit -> bool) =
 //find related
 let private findByCss cssSelector f =
     try
-        f(By.CssSelector(cssSelector)) |> List.ofSeq
+        f(BySizzle.CssSelector(cssSelector)) |> List.ofSeq
     with | ex -> []
 
 let private findByXpath xpath f =

--- a/canopy/canopy.fsproj
+++ b/canopy/canopy.fsproj
@@ -55,6 +55,14 @@
   <ItemGroup>
     <Reference Include="mscorlib" />
     <Reference Include="FSharp.Core" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\packages\Newtonsoft.Json.5.0.6\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="SizSelCsZzz">
+      <HintPath>..\..\packages\SizSelCsZzz.0.3.34.0\lib\SizSelCsZzz.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />

--- a/canopy/packages.config
+++ b/canopy/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net40" />
   <package id="Selenium.Support" version="2.35.0" targetFramework="net40" />
   <package id="Selenium.WebDriver" version="2.35.0" targetFramework="net40" />
+  <package id="SizSelCsZzz" version="0.3.34.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Converts canopy to use the sizzle selector engine instead of normal the WebDriver By.CssSelector using the SizSelCsZzz library.

Note that it's currently using Sizzle 1.6.2 - my next task is to submit a pull request to update it.
