### PR TITLE
Checking 'on' for non absolute URLs was waiting and using contains

### DIFF
--- a/basictests/Program.fs
+++ b/basictests/Program.fs
@@ -249,10 +249,21 @@ test (fun _ ->
 
 "Navigating to a url with query string should be on url with and without a query string" &&& fun _ ->
     let testpageWithQueryString = testpage + "?param1=weeeee"
-    let subtestpage = "http://lefthandedgoat.github.io/canopy"
     url testpageWithQueryString
     on testpageWithQueryString //with query string
     on testpage //without query string
+
+"Should be on a non absolute url" &&&& fun _ ->
+    let testpageWithQueryString = testpage + "?param1=weeeee"
+    url testpageWithQueryString
+
+    let path = (new System.UriBuilder(testpage)).Path
+    on path
+
+    //ensure all permutations of missing leading and trailing slashes work
+    on (path.TrimStart('/'))
+    on (path.TrimEnd('/'))
+    on (path.Trim('/'))
 
 "Should not be on partial url" &&& fun _ ->
     url testpage

--- a/canopy/canopy.fs
+++ b/canopy/canopy.fs
@@ -617,11 +617,14 @@ let quit browser =
 let currentUrl() = browser.Url
 
 let on (u: string) =
-    let urlSansQueryString u =
-        let uri = new System.Uri(u)
-        uri.GetLeftPart(System.UriPartial.Path)
+    let urlPath (u : string) =
+        let url = match u with
+                  | x when x.StartsWith("http") -> u //leave absolute urls alone
+                  | _ -> "http://host/" + u.Trim('/') + "/" //ensure valid uri
+        let uriBuilder = new System.UriBuilder(url)
+        uriBuilder.Path
     try
-        wait pageTimeout (fun _ -> browser.Url = u || urlSansQueryString(browser.Url) = u)
+        wait pageTimeout (fun _ -> if browser.Url = u then true else urlPath(browser.Url) = urlPath(u))
     with
         | ex -> if browser.Url.Contains(u) = false then raise (CanopyOnException(sprintf "on check failed, expected expression '%s' got %s" u browser.Url));
 


### PR DESCRIPTION
Now we use URI manipulation to ensure we are comparing the path part of the url.

Conflicts:
    canopy/canopy.fs
