### PR TITLE
Fixed situation where on would wait before doing a compare

### DIFF
--- a/canopy/canopy.fs
+++ b/canopy/canopy.fs
@@ -619,10 +619,10 @@ let currentUrl() = browser.Url
 let on (u: string) =
     let urlPath (u : string) =
         let url = match u with
-                  | x when x.StartsWith("http") -> u //leave absolute urls alone
-                  | _ -> "http://host/" + u.Trim('/') + "/" //ensure valid uri
+                  | x when x.StartsWith("http") -> u  //leave absolute urls alone 
+                  | _ -> "http://host/" + u.Trim('/') //ensure valid uri
         let uriBuilder = new System.UriBuilder(url)
-        uriBuilder.Path
+        uriBuilder.Path.TrimEnd('/') //get the path part removing trailing slashes
     try
         wait pageTimeout (fun _ -> if browser.Url = u then true else urlPath(browser.Url) = urlPath(u))
     with


### PR DESCRIPTION
`on` a browser.Url value having a trailing slash was waiting and then use compare and succeed. 

I noticed this when a few tests kept waiting the full timeout for an on assertion yet succeeding. The way I had it if the expected value did not have a trailing slash `on` would wait. 

I had a test for this but it is hard to notice that the test is taking longer due to a wait.
