### PR TITLE
The leading backslash in argument two in Path.Combine will make the... 

### DIFF
--- a/canopy/canopy.fs
+++ b/canopy/canopy.fs
@@ -752,7 +752,7 @@ let coverage (url : 'a) =
 
     on nonMutableInnerUrl
     selectors |> List.iter(fun cssSelector -> swallowedJs (script cssSelector))
-    let p = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"\canopy\")
+    let p = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"canopy\")
     let f = DateTime.Now.ToString("MMM-d_HH-mm-ss-fff")
     let ss = screenshot p f
     reporter.coverage nonMutableInnerUrl ss


### PR DESCRIPTION
...function return \canopy\ instead of %appdata%\canopy"
