### PR TITLE
Detect if browser (IWebDriver) supports taking screenshots

### DIFF
--- a/canopy/canopy.fs
+++ b/canopy/canopy.fs
@@ -31,13 +31,18 @@ let mutable browsers = []
 //misc
 let failsWith message = failureMessage <- message
 
-let screenshot directory filename =
+let private takeScreenshot directory filename =
     let pic = (browser :?> ITakesScreenshot).GetScreenshot().AsByteArray
     if not <| Directory.Exists(directory) 
         then Directory.CreateDirectory(directory) |> ignore
     IO.File.WriteAllBytes(Path.Combine(directory,filename + ".png"), pic)
     pic
-    
+
+let screenshot directory filename =
+    match box browser with 
+        | :? ITakesScreenshot -> takeScreenshot directory filename
+        | _ -> Array.empty<byte>
+
 let js script = (browser :?> IJavaScriptExecutor).ExecuteScript(script)
 
 let private swallowedJs script = try js script |> ignore with | ex -> ()


### PR DESCRIPTION
I'm spiking out using BrowserStack and it looks like the RemoteWebDriver does not support ITakesScreenshot by default. They have a way of working around it but I am guessing others will fall into this sort of problem.

Now I am not sure if my solution is the best. I am returning an empty byte array when screenshots are not supported. I'm guessing returning Some(byte[]) would be a more F# way of doing this. 

Thoughts?
