### PR TITLE
Reporter fail exception fix

### DIFF
--- a/src/canopy/configuration.fs
+++ b/src/canopy/configuration.fs
@@ -4,7 +4,7 @@ open System
 
 //runner related
 let failFast = ref false
-let failScheenshotPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\canopy\"
+let failScreenshotPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\canopy\"
 
 let mutable chromeDir = @"c:\"
 let mutable ieDir = @"c:\"

--- a/src/canopy/runner.fs
+++ b/src/canopy/runner.fs
@@ -53,7 +53,7 @@ let fail (ex : Exception) id =
         failedCount <- failedCount + 1
         contextFailed <- true
         let f = DateTime.Now.ToString("MMM-d_HH-mm-ss-fff")
-        let ss = screenshot configuration.failScheenshotPath f
+        let ss = screenshot configuration.failScreenshotPath f
         reporter.fail ex id ss
     with 
         | :? WebDriverException as failExc -> 


### PR DESCRIPTION
This is a small fix for the runner.fail method that can fail with a WebDriverTimeoutException.

Tested with a misbehaving website that sometimes aborted requests (crappy firewall). In the case of a misbehaving/stuck page the test would fail (after various timeouts) but the webdriver would still be stuck and the subsequent screenshot request would fail. Tested with the firefox webdriver.

Also added support for configuration of the screenshot path. 
