### PR TITLE
escape TC message attrib for common selenium msg

### DIFF
--- a/src/canopy/reporters.fs
+++ b/src/canopy/reporters.fs
@@ -103,7 +103,7 @@ type TeamCityReporter() =
         member this.pass () = consoleReporter.pass ()
     
         member this.fail ex id ss =         
-            consoleReporter.describe (String.Format("##teamcity[testFailed name='{0}' message='{1}']", id, ex.Message))
+            consoleReporter.describe (String.Format("##teamcity[testFailed name='{0}' message='{1}']", id, ex.Message.Replace("'", "|'")))
             consoleReporter.fail ex id ss
     
         member this.describe d = 


### PR DESCRIPTION
turns:
[10:24:50][testing a failure] ##teamcity[testFailed name='testing a
failure' message='can't find element #cantfindme']
[10:24:50][testing a failure] Property value not found Valid property
list format is (name( )_=( )_'escaped_value'( )_)_ where escape symbol
is "|"

into valid test/build failure msg:
[10:31:41][testing a failure] can't find element #cantfindme
