### PR TITLE
Added support for Safari, changes required to  run canopy on OSX and Linux(mono)

### DIFF
--- a/src/canopy/canopy.fs
+++ b/src/canopy/canopy.fs
@@ -27,6 +27,7 @@ let aurora = FirefoxWithPath(@"C:\Program Files (x86)\Aurora\firefox.exe")
 let ie = IE
 let chrome = Chrome
 let phantomJS = PhantomJS
+let safari = Safari
 let phantomJSProxyNone = PhantomJSProxyNone
   
 let mutable browsers = []
@@ -660,6 +661,7 @@ let start b =
     //also download IEDriverServer and place in c:\ or configure with ieDir
     //firefox just works
     //for phantomjs download it and put in c:\ or configure with phantomJSDir
+    //for Safari download it and put in c:\ or configure with safariDir
        
     browser <-        
         match b with
@@ -677,6 +679,7 @@ let start b =
         | FirefoxWithProfile profile -> new FirefoxDriver(profile) :> IWebDriver
         | FirefoxWithPath path -> new FirefoxDriver(Firefox.FirefoxBinary(path), Firefox.FirefoxProfile()) :> IWebDriver
         | FirefoxWithUserAgent userAgent -> firefoxWithUserAgent userAgent
+        | Safari ->new Safari.SafariDriver() :> IWebDriver
         | PhantomJS -> 
             autoPinBrowserRightOnLaunch <- false
             new PhantomJS.PhantomJSDriver(phantomJSDir) :> IWebDriver

--- a/src/canopy/configuration.fs
+++ b/src/canopy/configuration.fs
@@ -2,13 +2,23 @@
 open reporters
 open System
 
+//location of drivers depending on OS
+let FolderByOSType = 
+    if System.Environment.OSVersion.Platform = PlatformID.MacOSX then
+        @"/usr/bin/"
+    elif  System.Environment.OSVersion.Platform = PlatformID.Unix then
+        @"/usr/bin/"
+    else
+        @"c:\"
+
 //runner related
 let failFast = ref false
 let mutable failScreenshotPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\canopy\"
 
-let mutable chromeDir = @"c:\"
-let mutable ieDir = @"c:\"
-let mutable phantomJSDir = @"c:\"
+let mutable chromeDir = FolderByOSType
+let mutable ieDir = FolderByOSType
+let mutable phantomJSDir = FolderByOSType
+let mutable safariDir = FolderByOSType
 let mutable elementTimeout = 10.0
 let mutable compareTimeout = 10.0
 let mutable pageTimeout = 10.0

--- a/src/canopy/reporters.fs
+++ b/src/canopy/reporters.fs
@@ -186,6 +186,7 @@ type LiveHtmlReporter(browser : BrowserStartMode, driverPath : string) =
         | FirefoxWithPath path -> new OpenQA.Selenium.Firefox.FirefoxDriver(Firefox.FirefoxBinary(path), Firefox.FirefoxProfile()) :> IWebDriver
         | ChromeWithUserAgent userAgent -> raise(System.Exception("Sorry ChromeWithUserAgent can't be used for LiveHtmlReporter"))
         | FirefoxWithUserAgent userAgent -> raise(System.Exception("Sorry FirefoxWithUserAgent can't be used for LiveHtmlReporter"))
+        | Safari -> new OpenQA.Selenium.Safari.SafariDriver() :> IWebDriver
         | PhantomJS | PhantomJSProxyNone -> raise(System.Exception("Sorry PhantomJS can't be used for LiveHtmlReporter"))
         | Remote(_,_) -> raise(System.Exception("Sorry Remote can't be used for LiveHtmlReporter"))
                 

--- a/src/canopy/types.fs
+++ b/src/canopy/types.fs
@@ -46,6 +46,7 @@ type BrowserStartMode =
     | ChromeWithOptions of Chrome.ChromeOptions
     | ChromeWithOptionsAndTimeSpan of Chrome.ChromeOptions * TimeSpan
     | ChromeWithUserAgent of string
+    | Safari    
     | PhantomJS
     | PhantomJSProxyNone
     | Remote of string * ICapabilities

--- a/tests/basictests/Program.fs
+++ b/tests/basictests/Program.fs
@@ -8,7 +8,8 @@ open configuration
 open reporters
 open types
 
-start chrome
+//start chrome
+start Safari
 let mainBrowser = browser
 elementTimeout <- 3.0
 compareTimeout <- 3.0


### PR DESCRIPTION
- Added Safari to the supported browsers
- Different paths for the browser's driver depending on the OS

Tested changes on Windows(Chrome, IE, FireFox and Safari), Linux(Firefox and Chrome), OSX(Safari, Firefox, Chrome)