### PR TITLE
Improves performance of addition of contexts and addition of tests

### DIFF
--- a/tests/basictests/Program.fs
+++ b/tests/basictests/Program.fs
@@ -643,7 +643,7 @@ context "Resize tests"
     start chrome
     url "http://resizemybrowser.com/"
     resize screenSizes.iPhone4
-    "#cWidth" == "357"
+    "#cWidth" == "320"
     "#cHeight" == "480"
     quit browser
     switchTo mainBrowser
@@ -663,7 +663,7 @@ context "Resize tests"
     url "http://resizemybrowser.com/"
     resize screenSizes.iPhone4
     rotate()
-    "#cHeight" == "357"
+    "#cHeight" == "320"
     "#cWidth" == "480"
     quit browser
     switchTo mainBrowser
@@ -717,7 +717,7 @@ let createTestSuite contextName n =
 
 start chrome
 
-createTestSuite "Add test performance" 100000
+createTestSuite "Add test performance" 1000
 
 run ()
         

--- a/tests/basictests/Program.fs
+++ b/tests/basictests/Program.fs
@@ -643,7 +643,7 @@ context "Resize tests"
     start chrome
     url "http://resizemybrowser.com/"
     resize screenSizes.iPhone4
-    "#cWidth" == "320"
+    "#cWidth" == "357"
     "#cHeight" == "480"
     quit browser
     switchTo mainBrowser
@@ -663,7 +663,7 @@ context "Resize tests"
     url "http://resizemybrowser.com/"
     resize screenSizes.iPhone4
     rotate()
-    "#cHeight" == "320"
+    "#cHeight" == "357"
     "#cWidth" == "480"
     quit browser
     switchTo mainBrowser
@@ -698,6 +698,26 @@ context "Navigate tests"
 context "todo tests"
 
 "write a test that tests the whole internet!" &&& todo
+
+let createTest n =
+    let testName = sprintf "Testing welcome %i" n
+
+    let testBody _ = 
+        url testpage
+        "#welcome" == "Welcome"
+
+    testName &&& todo
+
+
+let createTestSuite contextName n =
+    context contextName
+
+    [1..n]
+    |> Seq.iter createTest
+
+start chrome
+
+createTestSuite "Add test performance" 100000
 
 run ()
         

--- a/tests/basictests/Program.fs
+++ b/tests/basictests/Program.fs
@@ -699,21 +699,14 @@ context "todo tests"
 
 "write a test that tests the whole internet!" &&& todo
 
-let createTest n =
-    let testName = sprintf "Testing welcome %i" n
-
-    let testBody _ = 
-        url testpage
-        "#welcome" == "Welcome"
-
+let createTest k =
+    let testName = sprintf "Testing addition performance %i" k
     testName &&& todo
-
 
 let createTestSuite contextName n =
     context contextName
 
-    [1..n]
-    |> Seq.iter createTest
+    [1..n] |> Seq.iter createTest
 
 start chrome
 


### PR DESCRIPTION
In my current project, I need to tests the results of a page with several thousand input cases. I have this cases in a test file and I decided to use canopy to dynamically create and run a test for each of them.

While doing this I have found that the functions that add tests are not efficient and adding several thousands of them will take a long time.

Concatenating two list to add a element, like in

    suites <- suites @ [s]

is an `O(n)` operation where `n` is the size of `suites`.
So, concatenating `n` lists of size 1 is an `O(n^2)` operation.

Adding an element to a list, like in 

    suites <- s::suites

is an `O(1)` operation. 

I have changed the concatenations to add an element to the end of a list, with an addition of the element to the front of the list. This have the effect that now the lists are in reverse order, so I also reversed the lists before using them in the `run` function. 

Reference
[Mastering F# Lists](http://blogs.msdn.com/b/chrsmith/archive/2008/07/10/mastering-f-lists.aspx)
