### PR TITLE
Swap order of arguments in (===)

### DIFF
--- a/src/canopy/canopy.fs
+++ b/src/canopy/canopy.fs
@@ -600,7 +600,7 @@ let is expected actual =
         raise (CanopyEqualityFailedException(sprintf "equality check failed.  expected: %O, got: %O" expected actual))
 
 (* documented/assertions *)
-let (===) expected actual = is expected actual
+let (===) actual expected = is expected actual
 
 let private shown (elem : IWebElement) =
     let opacity = elem.GetCssValue("opacity")


### PR DESCRIPTION
Swaps the order of the arguments on the (===) function so that you can write more fluent code.

For example `title() === "My Page"` when the title is blank gives an error message of `equality check failed.  expected: , got: My Page`