### PR TITLE
reporters: add timestamp to log in describe() func

### DIFF
--- a/src/canopy/reporters.fs
+++ b/src/canopy/reporters.fs
@@ -55,7 +55,9 @@ type ConsoleReporter() =
                         Console.WriteLine(trace)
                 Console.ResetColor())
 
-        member this.describe d = Console.WriteLine d
+        member this.describe text =
+            let now = DateTime.Now.ToString()
+            Console.WriteLine (sprintf "%s: %s" now text)
 
         member this.contextStart c = Console.WriteLine (String.Format("context: {0}", c))
 


### PR DESCRIPTION
When debugging flaky tests that may be caused by timing
issues, it's handy to have a timestamp of everything that
was going on in the test when it failed.