### PR TITLE
reporters: print all details of exception, not only the stack

### DIFF
--- a/src/canopy/reporters.fs
+++ b/src/canopy/reporters.fs
@@ -37,8 +37,8 @@ type ConsoleReporter() =
             Console.WriteLine(ex.Message);
             Console.Write("Url: ");
             Console.WriteLine(url);
-            Console.WriteLine("Stack: ");
-            ex.StackTrace.Split([| "\r\n"; "\n" |], StringSplitOptions.None)
+            Console.WriteLine("Exception details: ");
+            ex.ToString().Split([| "\r\n"; "\n" |], StringSplitOptions.None)
             |> Array.iter (fun trace ->
                 Console.ResetColor()
                 if trace.Contains(".FSharp.") || trace.Contains("canopy.core") || trace.Contains("OpenQA.Selenium") then


### PR DESCRIPTION
It's fine if canopy wants to highlight the error by printing
the exception message first, the URL, and then the details.

But the details of it shouldn't be just the stacktrace because:
- It doesn't contain the type of the exception.
- It doesn't contain details about InnerExceptions.

I found this the hard way: receiving a "One or more errors
occurred" error, and not knowing what was going on for a while.
Later I realized that the exception was AggregateException
(which normally wraps exceptions that happen in async/parallel
code), and that it had the best explanation in the InnerException
of it.