### PR TITLE
Make canopy not crash horribly on mono 64 bit.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ exit_code=$?
 if [ $exit_code -ne 0 ]; then
 	exit $exit_code
 fi
-  
+
 #workaround assembly resolution issues in build.fsx
 export FSHARPI=`which fsharpi`
 cat - > fsharpi <<"EOF"
@@ -20,5 +20,5 @@ libdir=$PWD/packages/FAKE/tools/
 $FSHARPI --lib:$libdir $@
 EOF
 chmod +x fsharpi
-mono packages/FAKE/tools/FAKE.exe build.fsx $@
+mono packages/FAKE/tools/FAKE.exe Build.fsx $@
 rm fsharpi

--- a/src/canopy/canopy.fs
+++ b/src/canopy/canopy.fs
@@ -67,9 +67,10 @@ let private saveScreenshot directory filename pic =
 
 let private takeScreenShotIfAlertUp () =
     try
-        let bitmap = new Bitmap(width= System.Windows.Forms.Screen.PrimaryScreen.Bounds.Width, height= System.Windows.Forms.Screen.PrimaryScreen.Bounds.Height, format=PixelFormat.Format32bppArgb);
+        let screenBounds = canopy.screen.getPrimaryScreenBounds ()
+        let bitmap = new Bitmap(width= screenBounds.width, height= screenBounds.height, format=PixelFormat.Format32bppArgb);
         use graphics = Graphics.FromImage(bitmap)
-        graphics.CopyFromScreen(System.Windows.Forms.Screen.PrimaryScreen.Bounds.X, System.Windows.Forms.Screen.PrimaryScreen.Bounds.Y, 0, 0, System.Windows.Forms.Screen.PrimaryScreen.Bounds.Size, CopyPixelOperation.SourceCopy);
+        graphics.CopyFromScreen(screenBounds.x, screenBounds.y, 0, 0, screenBounds.size, CopyPixelOperation.SourceCopy);
         use stream = new MemoryStream()
         bitmap.Save(stream, ImageFormat.Png)
         stream.Close()
@@ -98,7 +99,7 @@ let private pngToJpg pngArray =
 
   pngStream.Write(pngArray, 0, pngArray.Length)
   let img = Image.FromStream(pngStream)
-  
+
   img.Save(jpgStream, ImageFormat.Jpeg)
   jpgStream.ToArray()
 
@@ -756,20 +757,19 @@ let drag cssSelectorA cssSelectorB = cssSelectorA --> cssSelectorB
 //browser related
 (* documented/actions *)
 let pin direction =
-    let h = System.Windows.Forms.Screen.PrimaryScreen.WorkingArea.Height
-    let w = System.Windows.Forms.Screen.PrimaryScreen.WorkingArea.Width
+    let (w, h) = canopy.screen.getPrimaryScreenResolution ()
     let maxWidth = w / 2
-    browser.Manage().Window.Size <- new System.Drawing.Size(maxWidth,h)
+    browser.Manage().Window.Size <- new System.Drawing.Size(maxWidth, h)
     match direction with
-    | Left -> browser.Manage().Window.Position <- new System.Drawing.Point((maxWidth * 0),0)
-    | Right -> browser.Manage().Window.Position <- new System.Drawing.Point((maxWidth * 1),0)
+    | Left -> browser.Manage().Window.Position <- new System.Drawing.Point((maxWidth * 0), 0)
+    | Right -> browser.Manage().Window.Position <- new System.Drawing.Point((maxWidth * 1), 0)
     | FullScreen -> browser.Manage().Window.Maximize()
 
 (* documented/actions *)
 let pinToMonitor n =
     let n' = if n < 1 then 1 else n
-    if System.Windows.Forms.SystemInformation.MonitorCount >= n' then
-        let workingArea = System.Windows.Forms.Screen.AllScreens.[n'-1].WorkingArea
+    if canopy.screen.monitorCount >= n' then
+        let workingArea =  canopy.screen.allScreensWorkingArea.[n'-1]
         browser.Manage().Window.Position <- new System.Drawing.Point(workingArea.X, 0)
         browser.Manage().Window.Maximize()
     else

--- a/src/canopy/canopy.fsproj
+++ b/src/canopy/canopy.fsproj
@@ -52,6 +52,7 @@
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="types.fs" />
     <Compile Include="wait.fs" />
+    <Compile Include="screen.fs" />
     <Compile Include="reporters.fs" />
     <Compile Include="finders.fs" />
     <Compile Include="configuration.fs" />

--- a/src/canopy/reporters.fs
+++ b/src/canopy/reporters.fs
@@ -221,11 +221,10 @@ type LiveHtmlReporter(browser : BrowserStartMode, driverPath : string, ?pinBrows
         | Remote(_,_) -> raise(System.Exception("Sorry Remote can't be used for LiveHtmlReporter"))
 
     let pin () =
-        let h = System.Windows.Forms.Screen.PrimaryScreen.WorkingArea.Height;
-        let w = System.Windows.Forms.Screen.PrimaryScreen.WorkingArea.Width;
+        let (w, h) = canopy.screen.getPrimaryScreenResolution ()
         let maxWidth = w / 2
-        _browser.Manage().Window.Size <- new System.Drawing.Size(maxWidth,h);
-        _browser.Manage().Window.Position <- new System.Drawing.Point((maxWidth * 0),0);
+        _browser.Manage().Window.Size <- new System.Drawing.Size(maxWidth,h)
+        _browser.Manage().Window.Position <- new System.Drawing.Point((maxWidth * 0),0)
 
     let tryPin() =
         if pinBrowserRight then do pin()
@@ -399,11 +398,11 @@ type LiveHtmlReporter(browser : BrowserStartMode, driverPath : string, ?pinBrows
 type JUnitReporter(resultFilePath:string) =
 
     let consoleReporter : IReporter = new ConsoleReporter() :> IReporter
-    
+
     let testStopWatch = System.Diagnostics.Stopwatch()
     let testTimes = ResizeArray<string * float>()
     let passedTests = ResizeArray<string>()
-    let failedTests = ResizeArray<Exception * string>() 
+    let failedTests = ResizeArray<Exception * string>()
 
     interface IReporter with
 
@@ -438,7 +437,7 @@ type JUnitReporter(resultFilePath:string) =
             let testTimeSum = testTimes |> Seq.sumBy snd
             let allTestsXml = String.Join(String.Empty, Seq.concat [passedTestsXml; failedTestsXml])
             let xml =
-                sprintf "<testsuite tests=\"%i\" time=\"%.3f\">%s</testsuite>" testCount testTimeSum allTestsXml 
+                sprintf "<testsuite tests=\"%i\" time=\"%.3f\">%s</testsuite>" testCount testTimeSum allTestsXml
             let resultFile = System.IO.FileInfo(resultFilePath)
             resultFile.Directory.Create()
             consoleReporter.write <| sprintf "Saving results to %s" resultFilePath

--- a/src/canopy/screen.fs
+++ b/src/canopy/screen.fs
@@ -1,0 +1,76 @@
+namespace canopy
+module screen =
+
+    open System
+
+    type ScreenBoundary =
+        { width : int
+          height: int
+          x: int
+          y: int
+          size: Drawing.Size
+        }
+
+    module microsoftDotNet =
+        let getPrimaryScreenResolution () =
+            let h = System.Windows.Forms.Screen.PrimaryScreen.WorkingArea.Height
+            let w = System.Windows.Forms.Screen.PrimaryScreen.WorkingArea.Width
+            (w, h)
+
+        let getPrimaryScreenBounds () =
+            { width = System.Windows.Forms.Screen.PrimaryScreen.Bounds.Width
+              height = System.Windows.Forms.Screen.PrimaryScreen.Bounds.Height
+              x = System.Windows.Forms.Screen.PrimaryScreen.Bounds.X
+              y = System.Windows.Forms.Screen.PrimaryScreen.Bounds.Y
+              size = System.Windows.Forms.Screen.PrimaryScreen.Bounds.Size
+            }
+
+        let monitorCount () =
+            System.Windows.Forms.SystemInformation.MonitorCount
+
+        let allScreensWorkingArea () =
+            System.Windows.Forms.Screen.AllScreens
+            |> Array.map(fun x -> x.WorkingArea)
+
+
+    module mono =
+        let mutable screenWidth = 1280
+        let mutable screenHeight = 800
+
+        let getPrimaryScreenResolution () =
+            (screenWidth, screenHeight)
+
+        let getPrimaryScreenBounds () =
+            { width = screenWidth
+              height = screenHeight
+              x = 0
+              y = 0
+              size = Drawing.Size(screenWidth, screenHeight)
+            }
+
+        let monitorCount () =
+            1
+
+        let allScreensWorkingArea () =
+            [| Drawing.Rectangle(0, 0, screenWidth, screenHeight)
+            |]
+
+
+    let private is64BitMono =
+        Environment.Is64BitProcess && Type.GetType("Mono.Runtime") <> null
+
+    let getPrimaryScreenResolution () =
+        if is64BitMono then mono.getPrimaryScreenResolution ()
+        else microsoftDotNet.getPrimaryScreenResolution ()
+
+    let getPrimaryScreenBounds () =
+        if is64BitMono then mono.getPrimaryScreenBounds ()
+        else microsoftDotNet.getPrimaryScreenBounds ()
+
+    let monitorCount =
+        if is64BitMono then mono.monitorCount ()
+        else microsoftDotNet.monitorCount ()
+
+    let allScreensWorkingArea =
+        if is64BitMono then mono.allScreensWorkingArea ()
+        else microsoftDotNet.allScreensWorkingArea ()


### PR DESCRIPTION
I installed mono with brew, and apparently you only get 64bit mono (so no winforms).
Not knowing this, I tried canopy with the code in step 4 at http://lefthandedgoat.github.io/canopy/ 
And it crashed, not the experience one want so I fixed it.

