### PR TITLE
Give the JUnit test suite a name for the Jenkins JUnit parser

### DIFF
--- a/src/canopy/reporters.fs
+++ b/src/canopy/reporters.fs
@@ -437,7 +437,7 @@ type JUnitReporter(resultFilePath:string) =
             let testTimeSum = testTimes |> Seq.sumBy snd
             let allTestsXml = String.Join(String.Empty, Seq.concat [passedTestsXml; failedTestsXml])
             let xml =
-                sprintf "<testsuite tests=\"%i\" time=\"%.3f\">%s</testsuite>" testCount testTimeSum allTestsXml
+                sprintf "<testsuite name=\"canopy\" tests=\"%i\" time=\"%.3f\">%s</testsuite>" testCount testTimeSum allTestsXml
             let resultFile = System.IO.FileInfo(resultFilePath)
             resultFile.Directory.Create()
             consoleReporter.write <| sprintf "Saving results to %s" resultFilePath


### PR DESCRIPTION
I was trying to run some Canopy tests from Jenkins with the JUnit reporter enabled, and the Jenkins JUnit parser was failing when trying to parse the output.  Adding a name to the TestSuite resolved the issue.