### PR TITLE
Reporters: add timestamp to log in describe() func

### DIFF
--- a/src/canopy/reporters.fs
+++ b/src/canopy/reporters.fs
@@ -79,7 +79,9 @@ type ConsoleReporter() =
             Console.WriteLine("{0} failed", failed)
             Console.ResetColor()
 
-        member this.write w = Console.WriteLine w
+        member this.write text =
+            let now = DateTime.Now.ToString()
+            Console.WriteLine (sprintf "%s: %s" now text)
 
         member this.suggestSelectors selector suggestions =
             Console.ForegroundColor <- ConsoleColor.Yellow


### PR DESCRIPTION
When debugging tests case, having a timestamp on console outputs is
useful and would help developers to isolate timing issues.
This change was intended in MR318 but it was changing reporter.describe
and not reporter.write (which is called by canopy.describe).