### PR TITLE
Asserts: Case insensitive "contains" string check

### DIFF
--- a/docs/content/assertions.fsx
+++ b/docs/content/assertions.fsx
@@ -58,6 +58,13 @@ Assert that one string contains another.
 contains "Log" (read "#logout")
 
 (**
+containsInsensitive
+--------
+Assert that one string contains (case insensitive) another.
+*)
+containsInsensitive "Log" (read "#logout")
+
+(**
 notContains
 --------
 Assert that one string does not contains another.

--- a/src/canopy/canopy.fs
+++ b/src/canopy/canopy.fs
@@ -551,6 +551,13 @@ let contains (value1 : string) (value2 : string) =
         raise (CanopyContainsFailedException(sprintf "contains check failed.  %s does not contain %s" value2 value1))
 
 (* documented/assertions *)
+let containsInsensitive (value1 : string) (value2 : string) =
+    let rules = StringComparison.InvariantCultureIgnoreCase
+    let contains = value2.IndexOf(value1, rules)
+    if contains < 0 then
+        raise (CanopyContainsFailedException(sprintf "contains insensitive check failed.  %s does not contain %s" value2 value1))
+
+(* documented/assertions *)
 let notContains (value1 : string) (value2 : string) =
     if (value2.Contains(value1) = true) then
         raise (CanopyNotContainsFailedException(sprintf "notContains check failed.  %s does contain %s" value2 value1))


### PR DESCRIPTION
To compare 2 strings, "contains" function is checking in a case
sensitive way. Developers might need to have a case insensitive
contains to allow them to have more robust test cases.