### PR TITLE
Add fail if any wip tests config setting & docs

### DIFF
--- a/docs/content/configuration.fsx
+++ b/docs/content/configuration.fsx
@@ -112,6 +112,16 @@ wipSleep
 wipSleep <- 1.0
 
 (**
+failIfAnyWipTests
+--------
+* Prevents accidentally allowing wip tests into the build pipeline.
+* Set to false locally so tests under development are not affected.
+* Set to true in your CI environment to catch wip tests that have been mistakenly commited to trunk/master.
+* Default is false
+*)
+failIfAnyWipTests <- true
+
+(**
 runFailedContextsFirst
 -----
 * Runs failed contexts first if the test suite has already executed.

--- a/src/canopy/configuration.fs
+++ b/src/canopy/configuration.fs
@@ -48,6 +48,8 @@ let mutable pageTimeout = 10.0
 (* documented/configuration *)
 let mutable wipSleep = 1.0
 (* documented/configuration *)
+let mutable failIfAnyWipTests = false
+(* documented/configuration *)
 let mutable runFailedContextsFirst = false
 (* documented/configuration *)
 let mutable reporter : IReporter = new ConsoleReporter() :> IReporter

--- a/src/canopy/runner.fs
+++ b/src/canopy/runner.fs
@@ -179,6 +179,12 @@ let private runtest (suite : suite) (test : Test) =
 
 (* documented/testing *)
 let run () =
+
+    let wipsExist = suites |> List.exists (fun s -> s.Wips.IsEmpty = false)
+
+    if wipsExist && configuration.failIfAnyWipTests then
+       raise <| Exception "Wip tests found and failIfAnyWipTests is true"
+
     reporter.suiteBegin()
     let stopWatch = new Diagnostics.Stopwatch()
     stopWatch.Start()
@@ -194,7 +200,7 @@ let run () =
         suites <- fc @ pc
 
     //run only wips if there are any
-    if suites |> List.exists (fun s -> s.Wips.IsEmpty = false) then
+    if wipsExist then
         suites <- suites |> List.filter (fun s -> s.Wips.IsEmpty = false || s.Always.IsEmpty = false)
 
     suites


### PR DESCRIPTION
Recently in the project I'm working on I've committed changes with some canopy tests still marked as wip. This isn't easy to notice as the CI build has gone on to pass but only one or two tests were actually run.

The idea here is to prevent against accidentally pushed commits with wip marked tests by eagerly failing the build. The setting would be off by default but switched on in CI.

I don't know if using `raise` is the right way to fail but I'm assuming it would work.