### PR TITLE
canopy.classic.waitForElement function fix

### DIFF
--- a/src/canopy/canopy.fs
+++ b/src/canopy/canopy.fs
@@ -20,7 +20,7 @@ let edgeBETA = edgeBETA
 (* documented/actions *)
 let chrome = chrome
 (* documented/actions *)
-let chromium = chromium 
+let chromium = chromium
 (* documented/actions *)
 let safari = safari
 
@@ -158,7 +158,7 @@ let fastTextFromCSS selector = fastTextFromCSS selector browser
 let ( == ) item value = equals item value browser
 
 (* documented/assertions *)
-let ( != ) cssSelector value = notEquals cssSelector value browser 
+let ( != ) cssSelector value = notEquals cssSelector value browser
 
 (* documented/assertions *)
 let ( *= ) cssSelector value = oneOrManyEquals cssSelector value browser
@@ -183,12 +183,12 @@ let ( =~ ) cssSelector pattern = regexEquals cssSelector pattern browser
 
 (* documented/assertions *)
 let ( !=~ ) cssSelector pattern = regexNotEquals cssSelector pattern browser
- 
+
 (* documented/assertions *)
 let ( *~ ) cssSelector pattern = oneOrManyRegexEquals cssSelector pattern browser
 
 (* documented/assertions *)
-let is expected actual = is expected actual 
+let is expected actual = is expected actual
 
 (* documented/assertions *)
 let (===) expected actual = is expected actual
@@ -198,7 +198,7 @@ let displayed item = displayed item browser
 
 (* documented/assertions *)
 let notDisplayed item = notDisplayed item browser
-   
+
 (* documented/assertions *)
 let enabled item = enabled item browser
 
@@ -244,7 +244,7 @@ let drag cssSelectorA cssSelectorB = drag cssSelectorA cssSelectorB
 //browser related
 (* documented/actions *)
 let pin direction = pin direction browser
-    
+
 (* documented/actions *)
 let start b =
     browser <- start b
@@ -327,4 +327,4 @@ let value = value
 let skip message = skip message browser
 
 (* documented/actions *)
-let waitForElement cssSelector = waitForElement 
+let waitForElement cssSelector = waitForElement cssSelector

--- a/src/canopy/canopy.fs
+++ b/src/canopy/canopy.fs
@@ -327,4 +327,4 @@ let value = value
 let skip message = skip message browser
 
 (* documented/actions *)
-let waitForElement cssSelector = waitForElement cssSelector
+let waitForElement cssSelector = waitForElement cssSelector browser


### PR DESCRIPTION
`canopy.classic.waitForElement` is a proxy for `canopy.parallell.functions.waitForElement` but wasn't passing cssSelector parameter so signature was

```fsharp
val waitForElement: cssSelector: 'a -> string -> OpenQA.Selenium.IWebDriver -> unit
```

instead of

```fsharp
val waitForElement: cssSelector: string -> OpenQA.Selenium.IWebDriver -> unit
```

so I applied unused parameter since it was obvious fix.


More over in the old version of canopy we used to have this function signature

```fsharp
val waitForElement: cssSelector: string -> unit
```

and now we have 

```fsharp
val waitForElement: cssSelector: string -> OpenQA.Selenium.IWebDriver -> unit
```

so I passed `browser` as well to align it with old API and existing `skip` function from the same module `canopy.classic`.

My VSCode removed some empty spaces from line ends so PR looks pretty noisy instead of containing L330 only. I noticed too late :)
