### PR TITLE
Check 64-bit Firefox path on Windows before 32-bit path fallback

### DIFF
--- a/src/canopy/configuration.fs
+++ b/src/canopy/configuration.fs
@@ -26,7 +26,10 @@ let firefoxByOSType =
         if System.IO.File.Exists(@"/Applications/Firefox.app/Contents/MacOS/firefox-bin")
         then @"/Applications/Firefox.app/Contents/MacOS/firefox-bin" //osx
         else @"/usr/lib/firefox-2.0" //linux, unsure of correct path
-    | _ -> @"C:\Program Files (x86)\Mozilla Firefox\firefox.exe"
+    | _ ->
+        if System.IO.File.Exists(@"C:\Program Files\Mozilla Firefox\firefox.exe")
+        then @"C:\Program Files\Mozilla Firefox\firefox.exe" // 64-bit version
+        else @"C:\Program Files (x86)\Mozilla Firefox\firefox.exe"
 
 //runner related
 (* documented/configuration *)


### PR DESCRIPTION
Firefox didn't work without setting path manually for 64-bit version on Windows. This should be more universal solution.