### PR TITLE
Set correct path for Firefox on linux

### DIFF
--- a/src/canopy/configuration.fs
+++ b/src/canopy/configuration.fs
@@ -25,7 +25,7 @@ let firefoxByOSType =
     | PlatformID.Unix ->
         if System.IO.File.Exists(@"/Applications/Firefox.app/Contents/MacOS/firefox-bin")
         then @"/Applications/Firefox.app/Contents/MacOS/firefox-bin" //osx
-        else @"/usr/lib/firefox-2.0" //linux, unsure of correct path
+        else @"/usr/lib/firefox/firefox" //linux
     | _ ->
         if System.IO.File.Exists(@"C:\Program Files\Mozilla Firefox\firefox.exe")
         then @"C:\Program Files\Mozilla Firefox\firefox.exe" // 64-bit version


### PR DESCRIPTION
When running canopy on linux (Ubuntu 18.04) i get the following error message:
```
1541168288570 mozrunner::runner INFO Running command: "/usr/lib/firefox-2.0" "-marionette" "-foreground" "-no-remote" "-profile" "/tmp/rust_mozprofile.5HkpmFMeb2U6"

Unhandled Exception: System.InvalidOperationException: Failed to start browser /usr/lib/firefox-2.0: no such file or directory (SessionNotCreated)
```

Don't know what firefox-2.0 is actually, but /usr/lib/firefox/firefox is the correct path :)