### PR TITLE
Option to select WebDriver port and allow insecure SSL cert

### DIFF
--- a/docs/content/configuration.fsx
+++ b/docs/content/configuration.fsx
@@ -270,3 +270,21 @@ failureMessagesThatShoulBeTreatedAsSkip
 * Default is empty list
 *)
 failureMessagesThatShoulBeTreatedAsSkip <- ["message 1"; "message 2"]
+
+(**
+webdriverPort
+------------
+* Allow specifying a port on which the **WebDriver** instance wil start (instead of a random one)
+* Defualt is `None` and it **must** be an `Option` type, i.e. `None` or `Some x`
+* Do **NOT** use if running tests in parallel!
+*)
+webdriverPort <- Some 4444
+
+(**
+acceptInsecureSslCerts
+------------
+* Allow the driver to navigate to sites with self-signed SSL certificates
+* Crucial for Chrome Headless testing
+* Default is true
+*)
+acceptInsecureSslCerts <- true

--- a/src/canopy/canopy.parallell.functions.fs
+++ b/src/canopy/canopy.parallell.functions.fs
@@ -30,33 +30,36 @@ let chromium = Chromium
 (* documented/actions *)
 let safari = Safari
 
-let mutable browsers: OpenQA.Selenium.IWebDriver list = []
+let mutable browsers : OpenQA.Selenium.IWebDriver list = []
 
 //misc
-let private textOf (element: IWebElement) =
-    match element.TagName with
-    | "input" -> element.GetAttribute("value")
-    | "textarea" -> element.GetAttribute("value")
+let private textOf (element : IWebElement) =
+    match element.TagName  with
+    | "input" ->
+        element.GetAttribute("value")
+    | "textarea" ->
+        element.GetAttribute("value")
     | "select" ->
         let value = element.GetAttribute("value")
         let options = Seq.toList (element.FindElements(By.TagName("option")))
         let option = options |> List.filter (fun e -> e.GetAttribute("value") = value)
         option.Head.Text
-    | _ -> element.Text
+    | _ ->
+        element.Text
 
 let private regexMatch pattern input = System.Text.RegularExpressions.Regex.Match(input, pattern).Success
 
 let private saveScreenshot directory filename pic =
-    if not <| Directory.Exists(directory) then Directory.CreateDirectory(directory) |> ignore
-    IO.File.WriteAllBytes(Path.Combine(directory, filename + ".jpg"), pic)
+    if not <| Directory.Exists(directory)
+        then Directory.CreateDirectory(directory) |> ignore
+    IO.File.WriteAllBytes(Path.Combine(directory,filename + ".jpg"), pic)
 
-let private takeScreenShotIfAlertUp() =
+let private takeScreenShotIfAlertUp () =
     try
-        let screenBounds = canopy.screen.getPrimaryScreenBounds()
-        let bitmap =
-            new Bitmap(width = screenBounds.width, height = screenBounds.height, format = PixelFormat.Format32bppArgb)
+        let screenBounds = canopy.screen.getPrimaryScreenBounds ()
+        let bitmap = new Bitmap(width = screenBounds.width, height = screenBounds.height, format = PixelFormat.Format32bppArgb);
         use graphics = Graphics.FromImage(bitmap)
-        graphics.CopyFromScreen(screenBounds.x, screenBounds.y, 0, 0, screenBounds.size, CopyPixelOperation.SourceCopy)
+        graphics.CopyFromScreen(screenBounds.x, screenBounds.y, 0, 0, screenBounds.size, CopyPixelOperation.SourceCopy);
         use stream = new MemoryStream()
         bitmap.Save(stream, ImageFormat.Png)
         stream.Close()
@@ -66,49 +69,46 @@ let private takeScreenShotIfAlertUp() =
         Exception: %s" ex.Message
         Array.empty<byte>
 
-let private takeScreenshot directory filename (browser: IWebDriver) =
+let private takeScreenshot directory filename (browser : IWebDriver) =
     try
         let pic = (browser :?> ITakesScreenshot).GetScreenshot().AsByteArray
         saveScreenshot directory filename pic
         pic
-    with :? UnhandledAlertException as ex ->
-        let pic = takeScreenShotIfAlertUp()
-        saveScreenshot directory filename pic
-        let alert = browser.SwitchTo().Alert()
-        alert.Accept()
-        pic
+    with
+        | :? UnhandledAlertException as ex->
+            let pic = takeScreenShotIfAlertUp()
+            saveScreenshot directory filename pic
+            let alert = browser.SwitchTo().Alert()
+            alert.Accept()
+            pic
 
 let private pngToJpg pngArray =
-    let pngStream = new MemoryStream()
-    let jpgStream = new MemoryStream()
+  let pngStream = new MemoryStream()
+  let jpgStream = new MemoryStream()
 
-    pngStream.Write(pngArray, 0, pngArray.Length)
-    let img = Image.FromStream(pngStream)
+  pngStream.Write(pngArray, 0, pngArray.Length)
+  let img = Image.FromStream(pngStream)
 
-    img.Save(jpgStream, ImageFormat.Jpeg)
-    jpgStream.ToArray()
+  img.Save(jpgStream, ImageFormat.Jpeg)
+  jpgStream.ToArray()
 
 (* documented/actions *)
-let screenshot directory filename (browser: IWebDriver) =
+let screenshot directory filename (browser : IWebDriver) =
     match box browser with
-    | :? ITakesScreenshot -> takeScreenshot directory filename browser |> pngToJpg
-    | _ -> Array.empty<byte>
+        | :? ITakesScreenshot -> takeScreenshot directory filename browser |> pngToJpg
+        | _ -> Array.empty<byte>
 
 (* documented/actions *)
-let js script (browser: IWebDriver) = (browser :?> IJavaScriptExecutor).ExecuteScript(script)
+let js script (browser : IWebDriver) = (browser :?> IJavaScriptExecutor).ExecuteScript(script)
 
-let private swallowedJs script browser =
-    try
-        js script browser |> ignore
-    with ex -> ()
+let private swallowedJs script browser = try js script browser |> ignore with | ex -> ()
 
 (* documented/actions *)
 let sleep seconds =
-    let ms =
-        match box seconds with
-        | :? int as i -> i * 1000
-        | :? float as i -> Convert.ToInt32(i * 1000.0)
-        | _ -> 1000
+    let ms = match box seconds with
+              | :? int as i -> i * 1000
+              | :? float as i -> Convert.ToInt32(i * 1000.0)
+              | _ -> 1000
     System.Threading.Thread.Sleep(ms)
 
 (* documented/actions *)
@@ -178,91 +178,56 @@ let private suggestOtherSelectors cssSelector browser =
 	            }
             }
             return texts;"""
-
-        let safeSeq orig =
-            if isNull orig then Seq.empty
-            else orig
-
-        let safeToString orig =
-            if isNull orig then ""
-            else orig.ToString()
-
-        let classes =
-            js classesViaJs browser :?> ReadOnlyCollection<System.Object>
-            |> safeSeq
-            |> Seq.map (fun item -> "." + safeToString item)
-            |> Array.ofSeq
-
-        let ids =
-            js idsViaJs browser :?> ReadOnlyCollection<System.Object>
-            |> safeSeq
-            |> Seq.map (fun item -> "#" + safeToString item)
-            |> Array.ofSeq
-
-        let values =
-            js valuesViaJs browser :?> ReadOnlyCollection<System.Object>
-            |> safeSeq
-            |> Seq.map (fun item -> safeToString item)
-            |> Array.ofSeq
-
-        let texts =
-            js textsViaJs browser :?> ReadOnlyCollection<System.Object>
-            |> safeSeq
-            |> Seq.map (fun item -> safeToString item)
-            |> Array.ofSeq
+        let safeSeq orig = if orig = null then Seq.empty else orig
+        let safeToString orig = if orig = null then "" else orig.ToString()
+        let classes = js classesViaJs browser :?> ReadOnlyCollection<System.Object> |> safeSeq |> Seq.map (fun item -> "." + safeToString item) |> Array.ofSeq
+        let ids = js idsViaJs browser :?> ReadOnlyCollection<System.Object> |> safeSeq |> Seq.map (fun item -> "#" + safeToString item) |> Array.ofSeq
+        let values = js valuesViaJs browser :?> ReadOnlyCollection<System.Object> |> safeSeq |> Seq.map (fun item -> safeToString item) |> Array.ofSeq
+        let texts = js textsViaJs browser :?> ReadOnlyCollection<System.Object> |> safeSeq |> Seq.map (fun item -> safeToString item) |> Array.ofSeq
 
         let results =
             Array.append classes ids
             |> Array.append values
             |> Array.append texts
-            |> Seq.distinct
-            |> List.ofSeq
-            |> remove "."
-            |> remove "#"
-            |> Array.ofList
+            |> Seq.distinct |> List.ofSeq
+            |> remove "." |> remove "#" |> Array.ofList
             |> Array.Parallel.map (fun u -> editdistance cssSelector u)
-            |> Array.sortBy (fun r -> -r.similarity)
+            |> Array.sortBy (fun r -> - r.similarity)
 
         results
-        |> fun xs ->
-            if xs.Length >= 5 then Seq.take 5 xs
-            else Array.toSeq xs
-        |> Seq.map (fun r -> r.selector)
-        |> List.ofSeq
+        |> fun xs -> if xs.Length >= 5 then Seq.take 5 xs else Array.toSeq xs
+        |> Seq.map (fun r -> r.selector) |> List.ofSeq
         |> (fun suggestions -> reporter.suggestSelectors cssSelector suggestions)
 
 (* documented/actions *)
-let describe text browser = puts text browser
+let describe text browser =
+    puts text browser
 
 (* documented/actions *)
 let waitFor2 message f =
     try
         wait compareTimeout f
-    with :? WebDriverTimeoutException ->
-        raise
-            (CanopyWaitForException
-                (sprintf "%s%swaitFor condition failed to become true in %.1f seconds" message
-                     System.Environment.NewLine compareTimeout))
+    with
+        | :? WebDriverTimeoutException ->
+                raise (CanopyWaitForException(sprintf "%s%swaitFor condition failed to become true in %.1f seconds" message System.Environment.NewLine compareTimeout))
 
 (* documented/actions *)
-let waitFor =
-    waitFor2
-        "Condition not met in given amount of time. If you want to increase the time, put compareTimeout <- 10.0 anywhere before a test to increase the timeout"
+let waitFor = waitFor2 "Condition not met in given amount of time. If you want to increase the time, put compareTimeout <- 10.0 anywhere before a test to increase the timeout"
 
 //find related
-let rec private findElements cssSelector (searchContext: ISearchContext) (browser: IWebDriver): IWebElement list =
-    let findInIFrame() =
+let rec private findElements cssSelector (searchContext : ISearchContext) (browser : IWebDriver) : IWebElement list =
+    let findInIFrame () =
         let iframes = findByCss "iframe" searchContext.FindElements browser
         if iframes.IsEmpty then
             browser.SwitchTo().DefaultContent() |> ignore
             []
         else
             let webElements = ref []
-            iframes
-            |> List.iter (fun frame ->
+            iframes |> List.iter (fun frame ->
                 browser.SwitchTo().Frame(frame) |> ignore
                 let root = browser.FindElement(By.CssSelector("html"))
-                webElements := findElements cssSelector root browser)
+                webElements := findElements cssSelector root browser
+            )
             !webElements
 
     try
@@ -271,23 +236,19 @@ let rec private findElements cssSelector (searchContext: ISearchContext) (browse
                 let finders = hints.[cssSelector]
                 finders
                 |> Seq.map (fun finder -> finder cssSelector searchContext.FindElements browser)
-                |> Seq.filter (fun list -> not (list.IsEmpty))
+                |> Seq.filter(fun list -> not(list.IsEmpty))
             else
                 configuredFinders cssSelector searchContext.FindElements browser
-                |> Seq.filter (fun list -> not (list.IsEmpty))
+                |> Seq.filter(fun list -> not(list.IsEmpty))
         if Seq.isEmpty results then
-            if optimizeBySkippingIFrameCheck then []
-            else findInIFrame()
+            if optimizeBySkippingIFrameCheck then [] else findInIFrame()
         else
-            results |> Seq.head
-    with ex -> []
+           results |> Seq.head
+    with | ex -> []
 
-let private findByFunction cssSelector timeout waitFunc searchContext reliable (browser: IWebDriver) =
-    if browser = null then
-        raise
-            (CanopyNoBrowserException
-                ("Can't perform the action because the browser instance is null.  `start chrome` to start a new browser."))
-
+let private findByFunction cssSelector timeout waitFunc searchContext reliable (browser : IWebDriver) =
+    if browser = null then raise (CanopyNoBrowserException("Can't perform the action because the browser instance is null.  `start chrome` to start a new browser."))
+        
     if canopy.configuration.wipTest then colorizeAndSleep cssSelector browser
 
     try
@@ -299,9 +260,10 @@ let private findByFunction cssSelector timeout waitFunc searchContext reliable (
             !elements
         else
             waitResults elementTimeout (fun _ -> waitFunc cssSelector searchContext browser)
-    with :? WebDriverTimeoutException ->
-        suggestOtherSelectors cssSelector browser
-        raise (CanopyElementNotFoundException(sprintf "can't find element %s" cssSelector))
+    with
+        | :? WebDriverTimeoutException ->
+            suggestOtherSelectors cssSelector browser
+            raise (CanopyElementNotFoundException(sprintf "can't find element %s" cssSelector))
 
 let private find cssSelector timeout searchContext reliable browser =
     (findByFunction cssSelector timeout findElements searchContext reliable browser).Head
@@ -314,25 +276,17 @@ let private findMany cssSelector timeout searchContext reliable browser =
 let private elementFromList cssSelector elementsList =
     match elementsList with
     | [] -> null
-    | [ x ] -> x
+    | x :: [] -> x
     | x :: y :: _ ->
-        if throwIfMoreThanOneElement then
-            raise
-                (CanopyMoreThanOneElementFoundException
-                    (sprintf "More than one element was selected when only one was expected for selector: %s"
-                         cssSelector))
+        if throwIfMoreThanOneElement then raise (CanopyMoreThanOneElementFoundException(sprintf "More than one element was selected when only one was expected for selector: %s" cssSelector))
         else x
 
 let private someElementFromList cssSelector elementsList =
     match elementsList with
     | [] -> None
-    | [ x ] -> Some(x)
+    | x :: [] -> Some(x)
     | x :: y :: _ ->
-        if throwIfMoreThanOneElement then
-            raise
-                (CanopyMoreThanOneElementFoundException
-                    (sprintf "More than one element was selected when only one was expected for selector: %s"
-                         cssSelector))
+        if throwIfMoreThanOneElement then raise (CanopyMoreThanOneElementFoundException(sprintf "More than one element was selected when only one was expected for selector: %s" cssSelector))
         else Some(x)
 
 (* documented/actions *)
@@ -348,11 +302,12 @@ let unreliableElements cssSelector browser = findMany cssSelector elementTimeout
 let unreliableElement cssSelector browser = unreliableElements cssSelector browser |> elementFromList cssSelector
 
 (* documented/actions *)
-let elementWithin cssSelector (elem: IWebElement) = find cssSelector elementTimeout elem true
+let elementWithin cssSelector (elem:IWebElement) =  find cssSelector elementTimeout elem true
 
 (* documented/actions *)
 let elementsWithText cssSelector regex browser =
-    unreliableElements cssSelector browser |> List.filter (fun elem -> regexMatch regex (textOf elem))
+    unreliableElements cssSelector browser
+    |> List.filter (fun elem -> regexMatch regex (textOf elem))
 
 (* documented/actions *)
 let elementWithText cssSelector regex browser = (elementsWithText cssSelector regex browser).Head
@@ -370,8 +325,7 @@ let unreliableElementsWithin cssSelector elem = findMany cssSelector elementTime
 let someElement cssSelector browser = unreliableElements cssSelector browser |> someElementFromList cssSelector
 
 (* documented/actions *)
-let someElementWithin cssSelector elem browser =
-    unreliableElementsWithin cssSelector elem browser |> someElementFromList cssSelector
+let someElementWithin cssSelector elem browser = unreliableElementsWithin cssSelector elem browser |> someElementFromList cssSelector
 
 (* documented/actions *)
 let someParent elem browser = elementsWithin ".." elem browser |> someElementFromList "provided element"
@@ -386,66 +340,55 @@ let first cssSelector browser = (elements cssSelector browser).Head
 let last cssSelector browser = (List.rev (elements cssSelector browser)).Head
 
 //read/write
-let private writeToSelect (elem: IWebElement) (text: string) browser =
-    let options =
-        unreliableElementsWithin
-            (sprintf
-                """option[text()="%s"] | option[@value="%s"] | optgroup/option[text()="%s"] | optgroup/option[@value="%s"]"""
-                 text text text text) elem browser
-
+let private writeToSelect (elem:IWebElement) (text:string) browser =
+    let options = unreliableElementsWithin (sprintf """option[text()="%s"] | option[@value="%s"] | optgroup/option[text()="%s"] | optgroup/option[@value="%s"]""" text text text text) elem browser
+            
     match options with
     | [] -> raise (CanopyOptionNotFoundException(sprintf "element %s does not contain value %s" (elem.ToString()) text))
-    | head :: _ -> head.Click()
+    | head::_ -> head.Click()
 
-let private writeToElement (e: IWebElement) (text: string) browser =
+let private writeToElement (e : IWebElement) (text:string) browser =
     if e.TagName = "select" then
         writeToSelect e text browser
     else
         let readonly = e.GetAttribute("readonly")
         if readonly = "true" then
-            raise
-                (CanopyReadOnlyException
-                    (sprintf "element %s is marked as read only, you can not write to read only elements" (e.ToString())))
-        if not optimizeByDisablingClearBeforeWrite then
-            try
-                e.Clear()
-            with ex -> ex |> ignore
+            raise (CanopyReadOnlyException(sprintf "element %s is marked as read only, you can not write to read only elements" (e.ToString())))
+        if not optimizeByDisablingClearBeforeWrite then try e.Clear() with ex -> ex |> ignore
         e.SendKeys(text)
 
 (* documented/actions *)
 let write item text browser =
     match box item with
-    | :? IWebElement as elem -> writeToElement elem text browser
+    | :? IWebElement as elem ->  writeToElement elem text browser
     | :? string as cssSelector ->
         wait elementTimeout (fun _ ->
             elements cssSelector browser
-            |> List.map (fun elem ->
-                try
-                    writeToElement elem text browser
-                    true
-                with
-                //Note: Enrich exception with proper cssSelector description
-                | :? CanopyReadOnlyException ->
-                    raise
-                        (CanopyReadOnlyException
-                            (sprintf "element %s is marked as read only, you can not write to read only elements"
-                                 cssSelector))
-                | _ -> false)
-            |> List.exists (fun elem -> elem = true))
+                |> List.map (fun elem ->
+                    try
+                        writeToElement elem text browser
+                        true
+                    with
+                        //Note: Enrich exception with proper cssSelector description
+                        | :? CanopyReadOnlyException -> raise (CanopyReadOnlyException(sprintf "element %s is marked as read only, you can not write to read only elements" cssSelector))
+                        | _ -> false)
+                |> List.exists (fun elem -> elem = true)
+        )
     | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't read %O because it is not a string or element" item))
 
 let private safeRead item browser =
     let readvalue = ref ""
     try
         wait elementTimeout (fun _ ->
-            readvalue
-            := match box item with
-               | :? IWebElement as elem -> textOf elem
-               | :? string as cssSelector -> element cssSelector browser |> textOf
-               | _ -> raise (CanopyReadException("was unable to read item because it was not a string or IWebElement"))
-            true)
+          readvalue :=
+            match box item with
+            | :? IWebElement as elem -> textOf elem
+            | :? string as cssSelector -> element cssSelector browser |> textOf
+            | _ -> raise (CanopyReadException("was unable to read item because it was not a string or IWebElement"))
+          true)
         !readvalue
-    with :? WebDriverTimeoutException -> raise (CanopyReadException("was unable to read item for unknown reason"))
+    with
+        | :? WebDriverTimeoutException -> raise (CanopyReadException("was unable to read item for unknown reason"))
 
 (* documented/actions *)
 let read item browser =
@@ -456,48 +399,36 @@ let read item browser =
 
 (* documented/actions *)
 let clear item browser =
-    let clear cssSelector (elem: IWebElement) =
+    let clear cssSelector (elem : IWebElement) =
         let readonly = elem.GetAttribute("readonly")
-        if readonly = "true" then
-            raise
-                (CanopyReadOnlyException
-                    (sprintf "element %s is marked as read only, you can not clear read only elements" cssSelector))
+        if readonly = "true" then raise (CanopyReadOnlyException(sprintf "element %s is marked as read only, you can not clear read only elements" cssSelector))
         elem.Clear()
 
     match box item with
     | :? IWebElement as elem -> clear elem.TagName elem
     | :? string as cssSelector -> element cssSelector browser |> clear cssSelector
-    | _ ->
-        raise (CanopyNotStringOrElementException(sprintf "Can't clear %O because it is not a string or element" item))
+    | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't clear %O because it is not a string or element" item))
 
 //status
 (* documented/assertions *)
 let selected item browser =
-    let selected cssSelector (elem: IWebElement) =
-        if not <| elem.Selected then
-            raise (CanopySelectionFailedExeception(sprintf "element selected failed, %s not selected." cssSelector))
+    let selected cssSelector (elem : IWebElement) =
+        if not <| elem.Selected then raise (CanopySelectionFailedExeception(sprintf "element selected failed, %s not selected." cssSelector))
 
     match box item with
     | :? IWebElement as elem -> selected elem.TagName elem
     | :? string as cssSelector -> element cssSelector browser |> selected cssSelector
-    | _ ->
-        raise
-            (CanopyNotStringOrElementException
-                (sprintf "Can't check selected on %O because it is not a string or element" item))
+    | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't check selected on %O because it is not a string or element" item))
 
 (* documented/assertions *)
 let deselected item browser =
-    let deselected cssSelector (elem: IWebElement) =
-        if elem.Selected then
-            raise (CanopyDeselectionFailedException(sprintf "element deselected failed, %s selected." cssSelector))
+    let deselected cssSelector (elem : IWebElement) =
+        if elem.Selected then raise (CanopyDeselectionFailedException(sprintf "element deselected failed, %s selected." cssSelector))
 
     match box item with
     | :? IWebElement as elem -> deselected elem.TagName elem
     | :? string as cssSelector -> element cssSelector browser |> deselected cssSelector
-    | _ ->
-        raise
-            (CanopyNotStringOrElementException
-                (sprintf "Can't check deselected on %O because it is not a string or element" item))
+    | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't check deselected on %O because it is not a string or element" item))
 
 //keyboard
 (* documented/actions *)
@@ -522,36 +453,34 @@ let press key browser =
 
 //alerts
 (* documented/actions *)
-let alert (browser: IWebDriver) =
+let alert (browser : IWebDriver) =
     waitFor (fun _ ->
         browser.SwitchTo().Alert() |> ignore
         true)
     browser.SwitchTo().Alert()
 
 (* documented/actions *)
-let acceptAlert (browser: IWebDriver) =
+let acceptAlert (browser : IWebDriver) =
     wait compareTimeout (fun _ ->
         browser.SwitchTo().Alert().Accept()
         true)
 
 (* documented/actions *)
-let dismissAlert (browser: IWebDriver) =
+let dismissAlert (browser : IWebDriver) =
     wait compareTimeout (fun _ ->
         browser.SwitchTo().Alert().Dismiss()
         true)
 
 (* documented/actions *)
 let fastTextFromCSS selector browser =
-    let script =
-        //there is no map on NodeList which is the type returned by querySelectorAll =(
-        sprintf
-            """return [].map.call(document.querySelectorAll("%s"), function (item) { return item.text || item.innerText; });"""
-            selector
-    try
-        js script browser :?> System.Collections.ObjectModel.ReadOnlyCollection<System.Object>
-        |> Seq.map (fun item -> item.ToString())
-        |> List.ofSeq
-    with _ -> [ "default" ]
+  let script =
+    //there is no map on NodeList which is the type returned by querySelectorAll =(
+    sprintf """return [].map.call(document.querySelectorAll("%s"), function (item) { return item.text || item.innerText; });""" selector
+  try
+    js script browser :?> System.Collections.ObjectModel.ReadOnlyCollection<System.Object>
+    |> Seq.map (fun item -> item.ToString())
+    |> List.ofSeq
+  with | _ -> [ "default" ]
 
 //assertions
 (* documented/assertions *)
@@ -565,89 +494,59 @@ let equals item value browser =
     | :? string as cssSelector ->
         let bestvalue = ref ""
         try
-            wait compareTimeout (fun _ ->
-                (let readvalue = read cssSelector browser
-                 if readvalue <> value && readvalue <> "" then
-                     bestvalue := readvalue
-                     false
-                 else
-                     readvalue = value))
+            wait compareTimeout (fun _ -> ( let readvalue = read cssSelector browser
+                                            if readvalue <> value && readvalue <> "" then
+                                                bestvalue := readvalue
+                                                false
+                                            else
+                                                readvalue = value))
         with
-        | :? CanopyElementNotFoundException as ex ->
-            raise
-                (CanopyEqualityFailedException
-                    (sprintf "%s%sequality check failed.  expected: %s, got: %s" ex.Message Environment.NewLine value
-                         !bestvalue))
-        | :? WebDriverTimeoutException ->
-            raise
-                (CanopyEqualityFailedException(sprintf "equality check failed.  expected: %s, got: %s" value !bestvalue))
+            | :? CanopyElementNotFoundException as ex -> raise (CanopyEqualityFailedException(sprintf "%s%sequality check failed.  expected: %s, got: %s" ex.Message Environment.NewLine value !bestvalue))
+            | :? WebDriverTimeoutException -> raise (CanopyEqualityFailedException(sprintf "equality check failed.  expected: %s, got: %s" value !bestvalue))
 
-    | _ ->
-        raise
-            (CanopyNotStringOrElementException
-                (sprintf "Can't check equality on %O because it is not a string or alert" item))
+    | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't check equality on %O because it is not a string or alert" item))
 
 (* documented/assertions *)
 let notEquals cssSelector value browser =
     try
         wait compareTimeout (fun _ -> (read cssSelector browser) <> value)
     with
-    | :? CanopyElementNotFoundException as ex ->
-        raise
-            (CanopyNotEqualsFailedException
-                (sprintf "%s%snot equals check failed.  expected NOT: %s, got: " ex.Message Environment.NewLine value))
-    | :? WebDriverTimeoutException ->
-        raise
-            (CanopyNotEqualsFailedException
-                (sprintf "not equals check failed.  expected NOT: %s, got: %s" value (read cssSelector browser)))
+        | :? CanopyElementNotFoundException as ex -> raise (CanopyNotEqualsFailedException(sprintf "%s%snot equals check failed.  expected NOT: %s, got: " ex.Message Environment.NewLine value))
+        | :? WebDriverTimeoutException -> raise (CanopyNotEqualsFailedException(sprintf "not equals check failed.  expected NOT: %s, got: %s" value (read cssSelector browser)))
 
 (* documented/assertions *)
 let oneOrManyEquals cssSelector value browser =
     try
-        wait compareTimeout
-            (fun _ -> (elements cssSelector browser |> Seq.exists (fun element -> (textOf element) = value)))
+        wait compareTimeout (fun _ -> (elements cssSelector browser |> Seq.exists(fun element -> (textOf element) = value)))
     with
-    | :? CanopyElementNotFoundException as ex ->
-        raise
-            (CanopyValueNotInListException
-                (sprintf "%s%scan't find %s in list %s%sgot: " ex.Message Environment.NewLine value cssSelector
-                     Environment.NewLine))
-    | :? WebDriverTimeoutException ->
-        let sb = System.Text.StringBuilder()
-        elements cssSelector browser |> List.iter (fun e -> bprintf sb "%s%s" (textOf e) Environment.NewLine)
-        raise
-            (CanopyValueNotInListException
-                (sprintf "can't find %s in list %s%sgot: %s" value cssSelector Environment.NewLine (sb.ToString())))
+        | :? CanopyElementNotFoundException as ex -> raise (CanopyValueNotInListException(sprintf "%s%scan't find %s in list %s%sgot: " ex.Message Environment.NewLine value cssSelector Environment.NewLine))
+        | :? WebDriverTimeoutException ->
+            let sb = new System.Text.StringBuilder()
+            elements cssSelector browser |> List.iter (fun e -> bprintf sb "%s%s" (textOf e) Environment.NewLine)
+            raise (CanopyValueNotInListException(sprintf "can't find %s in list %s%sgot: %s" value cssSelector Environment.NewLine (sb.ToString())))
 
 (* documented/assertions *)
 let noneOfManyNotEquals cssSelector value browser =
     try
-        wait compareTimeout (fun _ ->
-            (elements cssSelector browser
-             |> Seq.exists (fun element -> (textOf element) = value)
-             |> not))
+        wait compareTimeout (fun _ -> (elements cssSelector browser |> Seq.exists(fun element -> (textOf element) = value) |> not))
     with
-    | :? CanopyElementNotFoundException as ex ->
-        raise (CanopyValueInListException(sprintf "%s%sfound check failed" ex.Message Environment.NewLine))
-    | :? WebDriverTimeoutException ->
-        raise (CanopyValueInListException(sprintf "found %s in list %s, expected not to" value cssSelector))
+        | :? CanopyElementNotFoundException as ex -> raise (CanopyValueInListException(sprintf "%s%sfound check failed" ex.Message Environment.NewLine))
+        | :? WebDriverTimeoutException -> raise (CanopyValueInListException(sprintf "found %s in list %s, expected not to" value cssSelector))
 
 (* documented/assertions *)
-let contains (value1: string) (value2: string) =
-    if not (value2.Contains(value1)) then
+let contains (value1 : string) (value2 : string) =
+    if (value2.Contains(value1) <> true) then
         raise (CanopyContainsFailedException(sprintf "contains check failed.  %s does not contain %s" value2 value1))
 
 (* documented/assertions *)
-let containsInsensitive (value1: string) (value2: string) =
+let containsInsensitive (value1 : string) (value2 : string) =
     let rules = StringComparison.InvariantCultureIgnoreCase
     let contains = value2.IndexOf(value1, rules)
     if contains < 0 then
-        raise
-            (CanopyContainsFailedException
-                (sprintf "contains insensitive check failed.  %s does not contain %s" value2 value1))
+        raise (CanopyContainsFailedException(sprintf "contains insensitive check failed.  %s does not contain %s" value2 value1))
 
 (* documented/assertions *)
-let notContains (value1: string) (value2: string) =
+let notContains (value1 : string) (value2 : string) =
     if (value2.Contains(value1) = true) then
         raise (CanopyNotContainsFailedException(sprintf "notContains check failed.  %s does contain %s" value2 value1))
 
@@ -656,63 +555,35 @@ let count cssSelector count browser =
     try
         wait compareTimeout (fun _ -> (unreliableElements cssSelector browser).Length = count)
     with
-    | :? CanopyElementNotFoundException as ex ->
-        raise
-            (CanopyCountException
-                (sprintf "%s%scount failed. expected: %i got: %i" ex.Message Environment.NewLine count 0))
-    | :? WebDriverTimeoutException ->
-        raise
-            (CanopyCountException
-                (sprintf "count failed. expected: %i got: %i" count (unreliableElements cssSelector browser).Length))
+        | :? CanopyElementNotFoundException as ex -> raise (CanopyCountException(sprintf "%s%scount failed. expected: %i got: %i" ex.Message Environment.NewLine count 0))
+        | :? WebDriverTimeoutException -> raise (CanopyCountException(sprintf "count failed. expected: %i got: %i" count (unreliableElements cssSelector browser).Length))
 
 (* documented/assertions *)
 let regexEquals cssSelector pattern browser =
     try
         wait compareTimeout (fun _ -> regexMatch pattern (read cssSelector browser))
     with
-    | :? CanopyElementNotFoundException as ex ->
-        raise
-            (CanopyEqualityFailedException
-                (sprintf "%s%sregex equality check failed.  expected: %s, got:" ex.Message Environment.NewLine pattern))
-    | :? WebDriverTimeoutException ->
-        raise
-            (CanopyEqualityFailedException
-                (sprintf "regex equality check failed.  expected: %s, got: %s" pattern (read cssSelector browser)))
+        | :? CanopyElementNotFoundException as ex -> raise (CanopyEqualityFailedException(sprintf "%s%sregex equality check failed.  expected: %s, got:" ex.Message Environment.NewLine pattern))
+        | :? WebDriverTimeoutException -> raise (CanopyEqualityFailedException(sprintf "regex equality check failed.  expected: %s, got: %s" pattern (read cssSelector browser)))
 
 (* documented/assertions *)
 let regexNotEquals cssSelector pattern browser =
     try
         wait compareTimeout (fun _ -> regexMatch pattern (read cssSelector browser) |> not)
     with
-    | :? CanopyElementNotFoundException as ex ->
-        raise
-            (CanopyEqualityFailedException
-                (sprintf "%s%sregex not equality check failed.  expected NOT: %s, got:" ex.Message Environment.NewLine
-                     pattern))
-    | :? WebDriverTimeoutException ->
-        raise
-            (CanopyEqualityFailedException
-                (sprintf "regex not equality check failed.  expected NOT: %s, got: %s" pattern
-                     (read cssSelector browser)))
+        | :? CanopyElementNotFoundException as ex -> raise (CanopyEqualityFailedException(sprintf "%s%sregex not equality check failed.  expected NOT: %s, got:" ex.Message Environment.NewLine pattern))
+        | :? WebDriverTimeoutException -> raise (CanopyEqualityFailedException(sprintf "regex not equality check failed.  expected NOT: %s, got: %s" pattern (read cssSelector browser)))
 
 (* documented/assertions *)
 let oneOrManyRegexEquals cssSelector pattern browser =
     try
-        wait compareTimeout
-            (fun _ -> (elements cssSelector browser |> Seq.exists (fun element -> regexMatch pattern (textOf element))))
+        wait compareTimeout (fun _ -> (elements cssSelector browser |> Seq.exists(fun element -> regexMatch pattern (textOf element))))
     with
-    | :? CanopyElementNotFoundException as ex ->
-        raise
-            (CanopyValueNotInListException
-                (sprintf "%s%scan't regex find %s in list %s%sgot: " ex.Message Environment.NewLine pattern cssSelector
-                     Environment.NewLine))
-    | :? WebDriverTimeoutException ->
-        let sb = System.Text.StringBuilder()
-        elements cssSelector browser |> List.iter (fun e -> bprintf sb "%s%s" (textOf e) Environment.NewLine)
-        raise
-            (CanopyValueNotInListException
-                (sprintf "can't regex find %s in list %s%sgot: %s" pattern cssSelector Environment.NewLine
-                     (sb.ToString())))
+        | :? CanopyElementNotFoundException as ex -> raise (CanopyValueNotInListException(sprintf "%s%scan't regex find %s in list %s%sgot: " ex.Message Environment.NewLine pattern cssSelector Environment.NewLine))
+        | :? WebDriverTimeoutException ->
+            let sb = new System.Text.StringBuilder()
+            elements cssSelector browser |> List.iter (fun e -> bprintf sb "%s%s" (textOf e) Environment.NewLine)
+            raise (CanopyValueNotInListException(sprintf "can't regex find %s in list %s%sgot: %s" pattern cssSelector Environment.NewLine (sb.ToString())))
 
 (* documented/assertions *)
 let is expected actual =
@@ -722,7 +593,7 @@ let is expected actual =
 (* documented/assertions *)
 let (===) expected actual = is expected actual
 
-let private shown (elem: IWebElement) =
+let private shown (elem : IWebElement) =
     let opacity = elem.GetCssValue("opacity")
     let display = elem.GetCssValue("display")
     display <> "none" && opacity = "1"
@@ -730,83 +601,50 @@ let private shown (elem: IWebElement) =
 (* documented/assertions *)
 let displayed item browser =
     try
-        wait compareTimeout
-            (fun _ ->
+        wait compareTimeout (fun _ ->
             match box item with
-            | :? IWebElement as element -> shown element
+            | :? IWebElement as element ->  shown element
             | :? string as cssSelector -> element cssSelector browser |> shown
-            | _ ->
-                raise
-                    (CanopyNotStringOrElementException
-                        (sprintf "Can't check displayed on %O because it is not a string or webelement" item)))
+            | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't check displayed on %O because it is not a string or webelement" item)))
     with
-    | :? CanopyElementNotFoundException as ex ->
-        raise
-            (CanopyDisplayedFailedException
-                (sprintf "%s%sdisplay check for %O failed." ex.Message Environment.NewLine item))
-    | :? WebDriverTimeoutException ->
-        raise (CanopyDisplayedFailedException(sprintf "display check for %O failed." item))
+        | :? CanopyElementNotFoundException as ex -> raise (CanopyDisplayedFailedException(sprintf "%s%sdisplay check for %O failed." ex.Message Environment.NewLine item))
+        | :? WebDriverTimeoutException -> raise (CanopyDisplayedFailedException(sprintf "display check for %O failed." item))
 
 (* documented/assertions *)
 let notDisplayed item browser =
     try
-        wait compareTimeout
-            (fun _ ->
+        wait compareTimeout (fun _ ->
             match box item with
-            | :? IWebElement as element -> not (shown element)
-            | :? string as cssSelector ->
-                (unreliableElements cssSelector browser |> List.isEmpty)
-                || not (unreliableElement cssSelector browser |> shown)
-            | _ ->
-                raise
-                    (CanopyNotStringOrElementException
-                        (sprintf "Can't check notDisplayed on %O because it is not a string or webelement" item)))
+            | :? IWebElement as element -> not(shown element)
+            | :? string as cssSelector -> (unreliableElements cssSelector browser |> List.isEmpty) || not(unreliableElement cssSelector browser |> shown)
+            | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't check notDisplayed on %O because it is not a string or webelement" item)))
     with
-    | :? CanopyElementNotFoundException as ex ->
-        raise
-            (CanopyNotDisplayedFailedException
-                (sprintf "%s%snotDisplay check for %O failed." ex.Message Environment.NewLine item))
-    | :? WebDriverTimeoutException ->
-        raise (CanopyNotDisplayedFailedException(sprintf "notDisplay check for %O failed." item))
+        | :? CanopyElementNotFoundException as ex -> raise (CanopyNotDisplayedFailedException(sprintf "%s%snotDisplay check for %O failed." ex.Message Environment.NewLine item))
+        | :? WebDriverTimeoutException -> raise (CanopyNotDisplayedFailedException(sprintf "notDisplay check for %O failed." item))
 
 (* documented/assertions *)
 let enabled item browser =
     try
-        wait compareTimeout
-            (fun _ ->
+        wait compareTimeout (fun _ ->
             match box item with
             | :? IWebElement as element -> element.Enabled = true
             | :? string as cssSelector -> (element cssSelector browser).Enabled = true
-            | _ ->
-                raise
-                    (CanopyNotStringOrElementException
-                        (sprintf "Can't check enabled on %O because it is not a string or webelement" item)))
+            | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't check enabled on %O because it is not a string or webelement" item)))
     with
-    | :? CanopyElementNotFoundException as ex ->
-        raise
-            (CanopyEnabledFailedException
-                (sprintf "%s%senabled check for %O failed." ex.Message Environment.NewLine item))
-    | :? WebDriverTimeoutException -> raise (CanopyEnabledFailedException(sprintf "enabled check for %O failed." item))
+        | :? CanopyElementNotFoundException as ex -> raise (CanopyEnabledFailedException(sprintf "%s%senabled check for %O failed." ex.Message Environment.NewLine item))
+        | :? WebDriverTimeoutException -> raise (CanopyEnabledFailedException(sprintf "enabled check for %O failed." item))
 
 (* documented/assertions *)
 let disabled item browser =
     try
-        wait compareTimeout
-            (fun _ ->
+        wait compareTimeout (fun _ ->
             match box item with
             | :? IWebElement as element -> element.Enabled = false
             | :? string as cssSelector -> (element cssSelector browser).Enabled = false
-            | _ ->
-                raise
-                    (CanopyNotStringOrElementException
-                        (sprintf "Can't check disabled on %O because it is not a string or webelement" item)))
+            | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't check disabled on %O because it is not a string or webelement" item)))
     with
-    | :? CanopyElementNotFoundException as ex ->
-        raise
-            (CanopyDisabledFailedException
-                (sprintf "%s%sdisabled check for %O failed." ex.Message Environment.NewLine item))
-    | :? WebDriverTimeoutException ->
-        raise (CanopyDisabledFailedException(sprintf "disabled check for %O failed." item))
+        | :? CanopyElementNotFoundException as ex -> raise (CanopyDisabledFailedException(sprintf "%s%sdisabled check for %O failed." ex.Message Environment.NewLine item))
+        | :? WebDriverTimeoutException -> raise (CanopyDisabledFailedException(sprintf "disabled check for %O failed." item))
 
 (* documented/assertions *)
 let fadedIn cssSelector browser = fun _ -> element cssSelector browser |> shown
@@ -824,112 +662,85 @@ let click item browser =
                 try
                     elem.Click()
                     atleastOneItemClicked := true
-                with ex -> ())
+                with | ex -> ())
             !atleastOneItemClicked)
-    | _ ->
-        raise
-            (CanopyNotStringOrElementException(sprintf "Can't click %O because it is not a string or webelement" item))
+    | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't click %O because it is not a string or webelement" item))
 
 (* documented/actions *)
-let doubleClick item (browser: IWebDriver) =
-    let js =
-        "var evt = document.createEvent('MouseEvents'); evt.initMouseEvent('dblclick',true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0,null); arguments[0].dispatchEvent(evt);"
+let doubleClick item (browser : IWebDriver) =
+    let js = "var evt = document.createEvent('MouseEvents'); evt.initMouseEvent('dblclick',true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0,null); arguments[0].dispatchEvent(evt);"
 
     match box item with
     | :? IWebElement as elem -> (browser :?> IJavaScriptExecutor).ExecuteScript(js, elem) |> ignore
     | :? string as cssSelector ->
-        wait elementTimeout (fun _ ->
-            (let elem = element cssSelector browser
-             (browser :?> IJavaScriptExecutor).ExecuteScript(js, elem) |> ignore
-             true))
-    | _ ->
-        raise
-            (CanopyNotStringOrElementException
-                (sprintf "Can't doubleClick %O because it is not a string or webelement" item))
+        wait elementTimeout (fun _ -> ( let elem = element cssSelector browser
+                                        (browser :?> IJavaScriptExecutor).ExecuteScript(js, elem) |> ignore
+                                        true))
+    | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't doubleClick %O because it is not a string or webelement" item))
 
 (* documented/actions *)
 let ctrlClick item browser =
-    let actions = Actions(browser)
+        let actions = Actions(browser)
 
-    match box item with
-    | :? IWebElement as elem -> actions.KeyDown(Keys.Control).Click(elem).KeyUp(Keys.Control).Perform() |> ignore
-    | :? string as cssSelector ->
-        wait elementTimeout (fun _ ->
-            (let elem = element cssSelector browser
-             actions.KeyDown(Keys.Control).Click(elem).KeyUp(Keys.Control).Perform()
-             true))
-    | _ ->
-        raise
-            (CanopyNotStringOrElementException
-                (sprintf "Can't ctrlClick %O because it is not a string or webelement" item))
+        match box item with
+        | :? IWebElement as elem -> actions.KeyDown(Keys.Control).Click(elem).KeyUp(Keys.Control).Perform() |> ignore
+        | :? string as cssSelector ->
+        wait elementTimeout (fun _ -> ( let elem = element cssSelector browser
+                                        actions.KeyDown(Keys.Control).Click(elem).KeyUp(Keys.Control).Perform()
+                                        true))
+        | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't ctrlClick %O because it is not a string or webelement" item))
 
 (* documented/actions *)
 let shiftClick item browser =
-    let actions = Actions(browser)
+        let actions = Actions(browser)
 
-    match box item with
-    | :? IWebElement as elem -> actions.KeyDown(Keys.Shift).Click(elem).KeyUp(Keys.Shift).Perform() |> ignore
-    | :? string as cssSelector ->
-        wait elementTimeout (fun _ ->
-            (let elem = element cssSelector browser
-             actions.KeyDown(Keys.Shift).Click(elem).KeyUp(Keys.Shift).Perform()
-             true))
-    | _ ->
-        raise
-            (CanopyNotStringOrElementException
-                (sprintf "Can't shiftClick %O because it is not a string or webelement" item))
+        match box item with
+        | :? IWebElement as elem -> actions.KeyDown(Keys.Shift).Click(elem).KeyUp(Keys.Shift).Perform() |> ignore
+        | :? string as cssSelector ->
+        wait elementTimeout (fun _ -> ( let elem = element cssSelector browser
+                                        actions.KeyDown(Keys.Shift).Click(elem).KeyUp(Keys.Shift).Perform()
+                                        true))
+        | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't shiftClick %O because it is not a string or webelement" item))
 
 (* documented/actions *)
 let rightClick item browser =
-    let actions = Actions(browser)
+        let actions = Actions(browser)
 
-    match box item with
-    | :? IWebElement as elem -> actions.ContextClick(elem).Perform() |> ignore
-    | :? string as cssSelector ->
-        wait elementTimeout (fun _ ->
-            (let elem = element cssSelector browser
-             actions.ContextClick(elem).Perform()
-             true))
-    | _ ->
-        raise
-            (CanopyNotStringOrElementException
-                (sprintf "Can't rightClick %O because it is not a string or webelement" item))
+        match box item with
+        | :? IWebElement as elem -> actions.ContextClick(elem).Perform() |> ignore
+        | :? string as cssSelector ->
+        wait elementTimeout (fun _ -> ( let elem = element cssSelector browser
+                                        actions.ContextClick(elem).Perform()
+                                        true))
+        | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't rightClick %O because it is not a string or webelement" item))
 
 (* documented/actions *)
 let check item browser =
     try
         match box item with
-        | :? IWebElement as elem ->
-            if not <| elem.Selected then click elem browser
+        | :? IWebElement as elem -> if not <| elem.Selected then click elem browser
         | :? string as cssSelector ->
             waitFor (fun _ ->
                 if not <| (element cssSelector browser).Selected then click cssSelector browser
                 (element cssSelector browser).Selected)
-        | _ ->
-            raise
-                (CanopyNotStringOrElementException(sprintf "Can't read %O because it is not a string or element" item))
+        | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't read %O because it is not a string or element" item))
     with
-    | :? CanopyElementNotFoundException as ex ->
-        raise (CanopyCheckFailedException(sprintf "%s%sfailed to check %O." ex.Message Environment.NewLine item))
-    | :? WebDriverTimeoutException -> raise (CanopyCheckFailedException(sprintf "failed to check %O." item))
+        | :? CanopyElementNotFoundException as ex -> raise (CanopyCheckFailedException(sprintf "%s%sfailed to check %O." ex.Message Environment.NewLine item))
+        | :? WebDriverTimeoutException -> raise (CanopyCheckFailedException(sprintf "failed to check %O." item))
 
 (* documented/actions *)
 let uncheck item browser =
     try
         match box item with
-        | :? IWebElement as elem ->
-            if elem.Selected then click elem browser
+        | :? IWebElement as elem -> if elem.Selected then click elem browser
         | :? string as cssSelector ->
             waitFor (fun _ ->
                 if (element cssSelector browser).Selected then click cssSelector browser
                 (element cssSelector browser).Selected = false)
-        | _ ->
-            raise
-                (CanopyNotStringOrElementException(sprintf "Can't read %O because it is not a string or element" item))
+        | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't read %O because it is not a string or element" item))
     with
-    | :? CanopyElementNotFoundException as ex ->
-        raise (CanopyUncheckFailedException(sprintf "%s%sfailed to uncheck %O." ex.Message Environment.NewLine item))
-    | :? WebDriverTimeoutException -> raise (CanopyUncheckFailedException(sprintf "failed to uncheck %O." item))
+        | :? CanopyElementNotFoundException as ex -> raise (CanopyUncheckFailedException(sprintf "%s%sfailed to uncheck %O." ex.Message Environment.NewLine item))
+        | :? WebDriverTimeoutException -> raise (CanopyUncheckFailedException(sprintf "failed to uncheck %O." item))
 
 //hoverin
 (* documented/actions *)
@@ -944,18 +755,18 @@ let drag cssSelectorA cssSelectorB browser =
     wait elementTimeout (fun _ ->
         let a = element cssSelectorA browser
         let b = element cssSelectorB browser
-        (Actions(browser)).DragAndDrop(a, b).Perform()
+        (new Actions(browser)).DragAndDrop(a, b).Perform()
         true)
 
 //browser related
 (* documented/actions *)
-let pin direction (browser: IWebDriver) =
-    let (w, h) = canopy.screen.getPrimaryScreenResolution()
+let pin direction (browser : IWebDriver) =
+    let (w, h) = canopy.screen.getPrimaryScreenResolution ()
     let maxWidth = w / 2
-    browser.Manage().Window.Size <- System.Drawing.Size(maxWidth, h)
+    browser.Manage().Window.Size <- new System.Drawing.Size(maxWidth, h)
     match direction with
-    | Left -> browser.Manage().Window.Position <- System.Drawing.Point(0, 0)
-    | Right -> browser.Manage().Window.Position <- System.Drawing.Point(maxWidth, 0)
+    | Left -> browser.Manage().Window.Position <- new System.Drawing.Point((maxWidth * 0), 0)
+    | Right -> browser.Manage().Window.Position <- new System.Drawing.Point((maxWidth * 1), 0)
     | FullScreen -> browser.Manage().Window.Maximize()
 
 let private firefoxDriverService _ =
@@ -965,17 +776,17 @@ let private firefoxDriverService _ =
     service.HideCommandPromptWindow <- hideCommandPromptWindow
     service
 
-let private firefoxWithUserAgent (userAgent: string) =
+let private firefoxWithUserAgent (userAgent : string) =
     let profile = FirefoxProfile()
     profile.SetPreference("general.useragent.override", userAgent)
-    let options = Firefox.FirefoxOptions()
+    let options = Firefox.FirefoxOptions();
     options.Profile <- profile
-    new FirefoxDriver(firefoxDriverService(), options, TimeSpan.FromSeconds(20.0)) :> IWebDriver
+    new FirefoxDriver(firefoxDriverService (), options, TimeSpan.FromSeconds(20.0)) :> IWebDriver
 
-let private chromeDriverService dir =
-    let service = Chrome.ChromeDriverService.CreateDefaultService(dir)
+let private chromeDriverService dir = 
+    let service = Chrome.ChromeDriverService.CreateDefaultService(dir);
     service.HostName <- driverHostName
-    service.HideCommandPromptWindow <- hideCommandPromptWindow
+    service.HideCommandPromptWindow <- hideCommandPromptWindow;
     match acceptInsecureSslCerts with
     | false -> ()
     | true -> service.WhitelistedIPAddresses <- ""
@@ -989,19 +800,19 @@ let private chromeWithUserAgent dir userAgent =
     options.AddArgument("--user-agent=" + userAgent)
     new Chrome.ChromeDriver(chromeDriverService dir, options) :> IWebDriver
 
-let private ieDriverService _ =
+let private ieDriverService _ = 
     let service = IE.InternetExplorerDriverService.CreateDefaultService(ieDir)
     service.HostName <- driverHostName
     service.HideCommandPromptWindow <- hideCommandPromptWindow
     service
 
-let private edgeDriverService _ =
+let private edgeDriverService _ = 
     let service = Edge.EdgeDriverService.CreateDefaultService(edgeDir)
     service.HostName <- driverHostName
     service.HideCommandPromptWindow <- hideCommandPromptWindow
     service
 
-let private safariDriverService _ =
+let private safariDriverService _ = 
     let service = Safari.SafariDriverService.CreateDefaultService(safariDir)
     service.HostName <- driverHostName
     service.HideCommandPromptWindow <- hideCommandPromptWindow
@@ -1018,20 +829,21 @@ let start b =
 
     let browser =
         match b with
-        | IE -> new IE.InternetExplorerDriver(ieDriverService()) :> IWebDriver
-        | IEWithOptions options -> new IE.InternetExplorerDriver(ieDriverService(), options) :> IWebDriver
-        | IEWithOptionsAndTimeSpan(options, timeSpan) ->
-            new IE.InternetExplorerDriver(ieDriverService(), options, timeSpan) :> IWebDriver
-        | EdgeBETA -> new Edge.EdgeDriver(edgeDriverService()) :> IWebDriver
+        | IE -> new IE.InternetExplorerDriver(ieDriverService ()) :> IWebDriver
+        | IEWithOptions options -> new IE.InternetExplorerDriver(ieDriverService (), options) :> IWebDriver
+        | IEWithOptionsAndTimeSpan(options, timeSpan) -> new IE.InternetExplorerDriver(ieDriverService (), options, timeSpan) :> IWebDriver
+        | EdgeBETA -> new Edge.EdgeDriver(edgeDriverService ()) :> IWebDriver
         | Chrome ->
             let options = Chrome.ChromeOptions()
             options.AddArgument("--disable-extensions")
             options.AddArgument("disable-infobars")
             options.AddArgument("test-type") //https://code.google.com/p/chromedriver/issues/detail?id=799
             new Chrome.ChromeDriver(chromeDriverService chromeDir, options) :> IWebDriver
-        | ChromeWithOptions options -> new Chrome.ChromeDriver(chromeDriverService chromeDir, options) :> IWebDriver
-        | ChromeWithUserAgent userAgent -> chromeWithUserAgent chromeDir userAgent
-        | ChromeWithOptionsAndTimeSpan(options, timeSpan) ->
+        | ChromeWithOptions options ->
+            new Chrome.ChromeDriver(chromeDriverService chromeDir, options) :> IWebDriver
+        | ChromeWithUserAgent userAgent -> 
+            chromeWithUserAgent chromeDir userAgent
+        | ChromeWithOptionsAndTimeSpan(options, timeSpan) -> 
             new Chrome.ChromeDriver(chromeDriverService chromeDir, options, timeSpan) :> IWebDriver
         | ChromeHeadless ->
             let options = Chrome.ChromeOptions()
@@ -1044,44 +856,43 @@ let start b =
             let options = Chrome.ChromeOptions()
             options.AddArgument("--disable-extensions")
             options.AddArgument("disable-infobars")
-            options.AddArgument("test-type") //https://code.google.com/p/chromedriver/issues/detail?id=799
+            options.AddArgument("test-type") //https://code.google.com/p/chromedriver/issues/detail?id=799            
             new Chrome.ChromeDriver(chromeDriverService chromiumDir, options) :> IWebDriver
         | ChromiumWithOptions options ->
             new Chrome.ChromeDriver(chromeDriverService chromiumDir, options) :> IWebDriver
-        | Firefox -> new FirefoxDriver(firefoxDriverService()) :> IWebDriver
-        | FirefoxWithPath path ->
-            let options = Firefox.FirefoxOptions()
-            options.BrowserExecutableLocation <- path
-            new FirefoxDriver(firefoxDriverService(), options, TimeSpan.FromSeconds(elementTimeout)) :> IWebDriver
+        | Firefox ->new FirefoxDriver(firefoxDriverService ()) :> IWebDriver
+        | FirefoxWithPath path -> 
+          let options = new Firefox.FirefoxOptions()
+          options.BrowserExecutableLocation <- path
+          new FirefoxDriver(firefoxDriverService (), options, TimeSpan.FromSeconds(elementTimeout)) :> IWebDriver
         | FirefoxWithUserAgent userAgent -> firefoxWithUserAgent userAgent
         | FirefoxWithOptions options ->
-            new FirefoxDriver(firefoxDriverService(), options, TimeSpan.FromSeconds(elementTimeout)) :> IWebDriver
-        | FirefoxWithPathAndTimeSpan(path, timespan) ->
-            let options = Firefox.FirefoxOptions()
-            options.BrowserExecutableLocation <- path
-            new FirefoxDriver(firefoxDriverService(), options, timespan) :> IWebDriver
-        | FirefoxWithProfileAndTimeSpan(profile, timespan) ->
-            let options = Firefox.FirefoxOptions()
-            options.Profile <- profile
-            new FirefoxDriver(firefoxDriverService(), options, timespan) :> IWebDriver
-        | FirefoxHeadless ->
-            let options = Firefox.FirefoxOptions()
+            new FirefoxDriver(firefoxDriverService (), options, TimeSpan.FromSeconds(elementTimeout)) :> IWebDriver
+        | FirefoxWithPathAndTimeSpan(path, timespan) -> 
+          let options = new Firefox.FirefoxOptions()
+          options.BrowserExecutableLocation <- path
+          new FirefoxDriver(firefoxDriverService (), options, timespan) :> IWebDriver
+        | FirefoxWithProfileAndTimeSpan(profile, timespan) -> 
+          let options = new Firefox.FirefoxOptions()
+          options.Profile <- profile
+          new FirefoxDriver(firefoxDriverService (), options, timespan) :> IWebDriver
+        | FirefoxHeadless -> 
+            let options = new Firefox.FirefoxOptions();
             options.AddArgument("--headless")
-            new FirefoxDriver(firefoxDriverService(), options, TimeSpan.FromSeconds(elementTimeout)) :> IWebDriver
-        | Safari -> new Safari.SafariDriver(safariDriverService()) :> IWebDriver
-        | Remote(url, capabilities) -> new Remote.RemoteWebDriver(Uri(url), capabilities) :> IWebDriver
+            new FirefoxDriver(firefoxDriverService (), options, TimeSpan.FromSeconds(elementTimeout)) :> IWebDriver
+        | Safari ->
+            new Safari.SafariDriver(safariDriverService ()) :> IWebDriver
+        | Remote(url, capabilities) -> new Remote.RemoteWebDriver(new Uri(url), capabilities) :> IWebDriver
 
-    if autoPinBrowserRightOnLaunch then pin Right browser
+    if autoPinBrowserRightOnLaunch = true then pin Right browser
     browser
 
 (* documented/actions *)
-let switchToTab number (browser: IWebDriver) =
+let switchToTab number (browser : IWebDriver) =
     wait pageTimeout (fun _ ->
         let number = number - 1
-        let tabs = browser.WindowHandles
-        if tabs
-           |> Seq.length
-           >= number then
+        let tabs = browser.WindowHandles;
+        if tabs |> Seq.length >= number then
             browser.SwitchTo().Window(tabs.[number]) |> ignore
             true
         else
@@ -1093,45 +904,45 @@ let closeTab number browser =
     browser.Close()
 
 (* documented/actions *)
-let tile (browsers: IWebDriver list) =
+let tile (browsers : IWebDriver list) =
     let h = canopy.screen.screenHeight
     let w = canopy.screen.screenWidth
     let count = browsers.Length
     let maxWidth = w / count
 
-    let rec setSize (browsers: IWebDriver list) c =
+    let rec setSize (browsers : IWebDriver list) c =
         match browsers with
         | [] -> ()
         | b :: tail ->
-            b.Manage().Window.Size <- System.Drawing.Size(maxWidth, h)
-            b.Manage().Window.Position <- System.Drawing.Point((maxWidth * c), 0)
+            b.Manage().Window.Size <- new System.Drawing.Size(maxWidth,h)
+            b.Manage().Window.Position <- new System.Drawing.Point((maxWidth * c),0)
             setSize tail (c + 1)
 
     setSize browsers 0
 
 (* documented/actions *)
-let positionBrowser left top width height (browser: IWebDriver) =
+let positionBrowser left top width height (browser : IWebDriver) =
     let h = canopy.screen.screenHeight
     let w = canopy.screen.screenWidth
 
     let x = left * w / 100
     let y = top * h / 100
-    let bw = width * w / 100
+    let bw = width * w /100
     let bh = height * h / 100
 
-    browser.Manage().Window.Size <- System.Drawing.Size(bw, bh)
-    browser.Manage().Window.Position <- System.Drawing.Point(x, y)
+    browser.Manage().Window.Size <- new System.Drawing.Size(bw, bh)
+    browser.Manage().Window.Position <- new System.Drawing.Point(x, y)
 
 
-let private innerSize (browser: IWebDriver) =
+let private innerSize (browser : IWebDriver) =
     let jsBrowser = browser :?> IJavaScriptExecutor
     let innerWidth = System.Int32.Parse(jsBrowser.ExecuteScript("return window.innerWidth").ToString())
     let innerHeight = System.Int32.Parse(jsBrowser.ExecuteScript("return window.innerHeight").ToString())
     innerWidth, innerHeight
 
 (* documented/actions *)
-let resize size (browser: IWebDriver) =
-    let width, height = size
+let resize size (browser : IWebDriver) =
+    let width,height = size
     let innerWidth, innerHeight = innerSize browser
     let newWidth = browser.Manage().Window.Size.Width - innerWidth + width
     let newHeight = browser.Manage().Window.Size.Height - innerHeight + height
@@ -1150,50 +961,45 @@ let quit browser =
     | _ -> ()
 
 (* documented/actions *)
-let currentUrl (browser: IWebDriver) = browser.Url
+let currentUrl (browser : IWebDriver) = browser.Url
 
 (* documented/assertions *)
-let onn (u: string) (browser: IWebDriver) =
-    let urlPath (u: string) =
-        let url =
-            match u with
-            | x when x.StartsWith("http") -> u //leave absolute urls alone
-            | _ -> "http://host/" + u.Trim('/') //ensure valid uri
-
-        let uriBuilder = System.UriBuilder(url)
+let onn (u: string) (browser : IWebDriver) =
+    let urlPath (u : string) =
+        let url = match u with
+                  | x when x.StartsWith("http") -> u  //leave absolute urls alone
+                  | _ -> "http://host/" + u.Trim('/') //ensure valid uri
+        let uriBuilder = new System.UriBuilder(url)
         uriBuilder.Path.TrimEnd('/') //get the path part removing trailing slashes
-    wait pageTimeout (fun _ ->
-        if browser.Url = u then true
-        else urlPath (browser.Url) = urlPath (u))
+    wait pageTimeout (fun _ -> if browser.Url = u then true else urlPath(browser.Url) = urlPath(u))
 
 (* documented/assertions *)
-let on (u: string) (browser: IWebDriver) =
+let on (u: string) (browser : IWebDriver) =
     try
         onn u browser
-    with ex ->
-        if not (browser.Url.Contains(u)) then
-            raise (CanopyOnException(sprintf "on check failed, expected expression '%s' got %s" u browser.Url))
+    with
+        | ex -> if browser.Url.Contains(u) = false then raise (CanopyOnException(sprintf "on check failed, expected expression '%s' got %s" u browser.Url))
 
 (* documented/actions *)
-let (!^) (u: string) (browser: IWebDriver) =
-    if isNull browser then
+let ( !^ ) (u : string) (browser : IWebDriver) =
+    if browser = null then
         raise (CanopyOnException "Can't navigate to the given url since the browser is not initialized.")
     browser.Navigate().GoToUrl(u)
 
 (* documented/actions *)
-let url u = !^u
+let url u = !^ u
 
 (* documented/actions *)
-let title (browser: IWebDriver) = browser.Title
+let title (browser : IWebDriver) = browser.Title
 
 (* documented/actions *)
-let reload browser =
-    let url' = currentUrl browser
-    url url' browser
+let reload browser = 
+  let url' = currentUrl browser 
+  url url' browser
 
 type Navigate =
-    | Back
-    | Forward
+  | Back
+  | Forward
 
 (* documented/actions *)
 let back = Back
@@ -1201,31 +1007,30 @@ let back = Back
 let forward = Forward
 
 (* documented/actions *)
-let navigate (browser: IWebDriver) direction =
-    match direction with
-    | Back -> browser.Navigate().Back()
-    | Forward -> browser.Navigate().Forward()
+let navigate (browser : IWebDriver) direction = 
+  match direction with
+  | Back -> browser.Navigate().Back()
+  | Forward -> browser.Navigate().Forward()
 
 (* documented/actions *)
 let addFinder finder browser =
     let currentFinders = configuredFinders
-    configuredFinders <-
-        (fun cssSelector browser f ->
-        currentFinders cssSelector browser f |> Seq.append (seq { yield finder cssSelector browser f }))
+    configuredFinders <- (fun cssSelector browser f ->
+        currentFinders cssSelector browser f
+        |> Seq.append (seq { yield finder cssSelector browser f }))
 
 //hints
 let private addHintFinder hints finder = hints |> Seq.append (seq { yield finder })
-
 (* DONT/documented/actions *)
 let addSelector finder hintType selector =
     //gaurd against adding same hintType multipe times and increase size of finder seq
     if not <| (hints.ContainsKey(selector) && addedHints.[selector] |> List.exists (fun hint -> hint = hintType)) then
         if hints.ContainsKey(selector) then
             hints.[selector] <- addHintFinder hints.[selector] finder
-            addedHints.[selector] <- [ hintType ] @ addedHints.[selector]
+            addedHints.[selector] <- [hintType] @ addedHints.[selector]
         else
             hints.[selector] <- seq { yield finder }
-            addedHints.[selector] <- [ hintType ]
+            addedHints.[selector] <- [hintType]
     selector
 
 (* documented/actions *)
@@ -1242,8 +1047,9 @@ let text = addSelector findByText "text"
 let value = addSelector findByValue "value"
 
 let skip message browser =
-    describe (sprintf "Skipped: %s" message) browser
-    raise <| CanopySkipTestException()
+  describe (sprintf "Skipped: %s" message) browser
+  raise <| CanopySkipTestException()
 
 (* documented/actions *)
-let waitForElement cssSelector browser = waitFor (fun _ -> someElement cssSelector browser |> Option.isSome)
+let waitForElement cssSelector browser =
+    waitFor (fun _ -> someElement cssSelector browser |> Option.isSome)

--- a/src/canopy/canopy.parallell.functions.fs
+++ b/src/canopy/canopy.parallell.functions.fs
@@ -30,36 +30,33 @@ let chromium = Chromium
 (* documented/actions *)
 let safari = Safari
 
-let mutable browsers : OpenQA.Selenium.IWebDriver list = []
+let mutable browsers: OpenQA.Selenium.IWebDriver list = []
 
 //misc
-let private textOf (element : IWebElement) =
-    match element.TagName  with
-    | "input" ->
-        element.GetAttribute("value")
-    | "textarea" ->
-        element.GetAttribute("value")
+let private textOf (element: IWebElement) =
+    match element.TagName with
+    | "input" -> element.GetAttribute("value")
+    | "textarea" -> element.GetAttribute("value")
     | "select" ->
         let value = element.GetAttribute("value")
         let options = Seq.toList (element.FindElements(By.TagName("option")))
         let option = options |> List.filter (fun e -> e.GetAttribute("value") = value)
         option.Head.Text
-    | _ ->
-        element.Text
+    | _ -> element.Text
 
 let private regexMatch pattern input = System.Text.RegularExpressions.Regex.Match(input, pattern).Success
 
 let private saveScreenshot directory filename pic =
-    if not <| Directory.Exists(directory)
-        then Directory.CreateDirectory(directory) |> ignore
-    IO.File.WriteAllBytes(Path.Combine(directory,filename + ".jpg"), pic)
+    if not <| Directory.Exists(directory) then Directory.CreateDirectory(directory) |> ignore
+    IO.File.WriteAllBytes(Path.Combine(directory, filename + ".jpg"), pic)
 
-let private takeScreenShotIfAlertUp () =
+let private takeScreenShotIfAlertUp() =
     try
-        let screenBounds = canopy.screen.getPrimaryScreenBounds ()
-        let bitmap = new Bitmap(width = screenBounds.width, height = screenBounds.height, format = PixelFormat.Format32bppArgb);
+        let screenBounds = canopy.screen.getPrimaryScreenBounds()
+        let bitmap =
+            new Bitmap(width = screenBounds.width, height = screenBounds.height, format = PixelFormat.Format32bppArgb)
         use graphics = Graphics.FromImage(bitmap)
-        graphics.CopyFromScreen(screenBounds.x, screenBounds.y, 0, 0, screenBounds.size, CopyPixelOperation.SourceCopy);
+        graphics.CopyFromScreen(screenBounds.x, screenBounds.y, 0, 0, screenBounds.size, CopyPixelOperation.SourceCopy)
         use stream = new MemoryStream()
         bitmap.Save(stream, ImageFormat.Png)
         stream.Close()
@@ -69,46 +66,49 @@ let private takeScreenShotIfAlertUp () =
         Exception: %s" ex.Message
         Array.empty<byte>
 
-let private takeScreenshot directory filename (browser : IWebDriver) =
+let private takeScreenshot directory filename (browser: IWebDriver) =
     try
         let pic = (browser :?> ITakesScreenshot).GetScreenshot().AsByteArray
         saveScreenshot directory filename pic
         pic
-    with
-        | :? UnhandledAlertException as ex->
-            let pic = takeScreenShotIfAlertUp()
-            saveScreenshot directory filename pic
-            let alert = browser.SwitchTo().Alert()
-            alert.Accept()
-            pic
+    with :? UnhandledAlertException as ex ->
+        let pic = takeScreenShotIfAlertUp()
+        saveScreenshot directory filename pic
+        let alert = browser.SwitchTo().Alert()
+        alert.Accept()
+        pic
 
 let private pngToJpg pngArray =
-  let pngStream = new MemoryStream()
-  let jpgStream = new MemoryStream()
+    let pngStream = new MemoryStream()
+    let jpgStream = new MemoryStream()
 
-  pngStream.Write(pngArray, 0, pngArray.Length)
-  let img = Image.FromStream(pngStream)
+    pngStream.Write(pngArray, 0, pngArray.Length)
+    let img = Image.FromStream(pngStream)
 
-  img.Save(jpgStream, ImageFormat.Jpeg)
-  jpgStream.ToArray()
+    img.Save(jpgStream, ImageFormat.Jpeg)
+    jpgStream.ToArray()
 
 (* documented/actions *)
-let screenshot directory filename (browser : IWebDriver) =
+let screenshot directory filename (browser: IWebDriver) =
     match box browser with
-        | :? ITakesScreenshot -> takeScreenshot directory filename browser |> pngToJpg
-        | _ -> Array.empty<byte>
+    | :? ITakesScreenshot -> takeScreenshot directory filename browser |> pngToJpg
+    | _ -> Array.empty<byte>
 
 (* documented/actions *)
-let js script (browser : IWebDriver) = (browser :?> IJavaScriptExecutor).ExecuteScript(script)
+let js script (browser: IWebDriver) = (browser :?> IJavaScriptExecutor).ExecuteScript(script)
 
-let private swallowedJs script browser = try js script browser |> ignore with | ex -> ()
+let private swallowedJs script browser =
+    try
+        js script browser |> ignore
+    with ex -> ()
 
 (* documented/actions *)
 let sleep seconds =
-    let ms = match box seconds with
-              | :? int as i -> i * 1000
-              | :? float as i -> Convert.ToInt32(i * 1000.0)
-              | _ -> 1000
+    let ms =
+        match box seconds with
+        | :? int as i -> i * 1000
+        | :? float as i -> Convert.ToInt32(i * 1000.0)
+        | _ -> 1000
     System.Threading.Thread.Sleep(ms)
 
 (* documented/actions *)
@@ -178,56 +178,91 @@ let private suggestOtherSelectors cssSelector browser =
 	            }
             }
             return texts;"""
-        let safeSeq orig = if orig = null then Seq.empty else orig
-        let safeToString orig = if orig = null then "" else orig.ToString()
-        let classes = js classesViaJs browser :?> ReadOnlyCollection<System.Object> |> safeSeq |> Seq.map (fun item -> "." + safeToString item) |> Array.ofSeq
-        let ids = js idsViaJs browser :?> ReadOnlyCollection<System.Object> |> safeSeq |> Seq.map (fun item -> "#" + safeToString item) |> Array.ofSeq
-        let values = js valuesViaJs browser :?> ReadOnlyCollection<System.Object> |> safeSeq |> Seq.map (fun item -> safeToString item) |> Array.ofSeq
-        let texts = js textsViaJs browser :?> ReadOnlyCollection<System.Object> |> safeSeq |> Seq.map (fun item -> safeToString item) |> Array.ofSeq
+
+        let safeSeq orig =
+            if isNull orig then Seq.empty
+            else orig
+
+        let safeToString orig =
+            if isNull orig then ""
+            else orig.ToString()
+
+        let classes =
+            js classesViaJs browser :?> ReadOnlyCollection<System.Object>
+            |> safeSeq
+            |> Seq.map (fun item -> "." + safeToString item)
+            |> Array.ofSeq
+
+        let ids =
+            js idsViaJs browser :?> ReadOnlyCollection<System.Object>
+            |> safeSeq
+            |> Seq.map (fun item -> "#" + safeToString item)
+            |> Array.ofSeq
+
+        let values =
+            js valuesViaJs browser :?> ReadOnlyCollection<System.Object>
+            |> safeSeq
+            |> Seq.map (fun item -> safeToString item)
+            |> Array.ofSeq
+
+        let texts =
+            js textsViaJs browser :?> ReadOnlyCollection<System.Object>
+            |> safeSeq
+            |> Seq.map (fun item -> safeToString item)
+            |> Array.ofSeq
 
         let results =
             Array.append classes ids
             |> Array.append values
             |> Array.append texts
-            |> Seq.distinct |> List.ofSeq
-            |> remove "." |> remove "#" |> Array.ofList
+            |> Seq.distinct
+            |> List.ofSeq
+            |> remove "."
+            |> remove "#"
+            |> Array.ofList
             |> Array.Parallel.map (fun u -> editdistance cssSelector u)
-            |> Array.sortBy (fun r -> - r.similarity)
+            |> Array.sortBy (fun r -> -r.similarity)
 
         results
-        |> fun xs -> if xs.Length >= 5 then Seq.take 5 xs else Array.toSeq xs
-        |> Seq.map (fun r -> r.selector) |> List.ofSeq
+        |> fun xs ->
+            if xs.Length >= 5 then Seq.take 5 xs
+            else Array.toSeq xs
+        |> Seq.map (fun r -> r.selector)
+        |> List.ofSeq
         |> (fun suggestions -> reporter.suggestSelectors cssSelector suggestions)
 
 (* documented/actions *)
-let describe text browser =
-    puts text browser
+let describe text browser = puts text browser
 
 (* documented/actions *)
 let waitFor2 message f =
     try
         wait compareTimeout f
-    with
-        | :? WebDriverTimeoutException ->
-                raise (CanopyWaitForException(sprintf "%s%swaitFor condition failed to become true in %.1f seconds" message System.Environment.NewLine compareTimeout))
+    with :? WebDriverTimeoutException ->
+        raise
+            (CanopyWaitForException
+                (sprintf "%s%swaitFor condition failed to become true in %.1f seconds" message
+                     System.Environment.NewLine compareTimeout))
 
 (* documented/actions *)
-let waitFor = waitFor2 "Condition not met in given amount of time. If you want to increase the time, put compareTimeout <- 10.0 anywhere before a test to increase the timeout"
+let waitFor =
+    waitFor2
+        "Condition not met in given amount of time. If you want to increase the time, put compareTimeout <- 10.0 anywhere before a test to increase the timeout"
 
 //find related
-let rec private findElements cssSelector (searchContext : ISearchContext) (browser : IWebDriver) : IWebElement list =
-    let findInIFrame () =
+let rec private findElements cssSelector (searchContext: ISearchContext) (browser: IWebDriver): IWebElement list =
+    let findInIFrame() =
         let iframes = findByCss "iframe" searchContext.FindElements browser
         if iframes.IsEmpty then
             browser.SwitchTo().DefaultContent() |> ignore
             []
         else
             let webElements = ref []
-            iframes |> List.iter (fun frame ->
+            iframes
+            |> List.iter (fun frame ->
                 browser.SwitchTo().Frame(frame) |> ignore
                 let root = browser.FindElement(By.CssSelector("html"))
-                webElements := findElements cssSelector root browser
-            )
+                webElements := findElements cssSelector root browser)
             !webElements
 
     try
@@ -236,19 +271,23 @@ let rec private findElements cssSelector (searchContext : ISearchContext) (brows
                 let finders = hints.[cssSelector]
                 finders
                 |> Seq.map (fun finder -> finder cssSelector searchContext.FindElements browser)
-                |> Seq.filter(fun list -> not(list.IsEmpty))
+                |> Seq.filter (fun list -> not (list.IsEmpty))
             else
                 configuredFinders cssSelector searchContext.FindElements browser
-                |> Seq.filter(fun list -> not(list.IsEmpty))
+                |> Seq.filter (fun list -> not (list.IsEmpty))
         if Seq.isEmpty results then
-            if optimizeBySkippingIFrameCheck then [] else findInIFrame()
+            if optimizeBySkippingIFrameCheck then []
+            else findInIFrame()
         else
-           results |> Seq.head
-    with | ex -> []
+            results |> Seq.head
+    with ex -> []
 
-let private findByFunction cssSelector timeout waitFunc searchContext reliable (browser : IWebDriver) =
-    if browser = null then raise (CanopyNoBrowserException("Can't perform the action because the browser instance is null.  `start chrome` to start a new browser."))
-        
+let private findByFunction cssSelector timeout waitFunc searchContext reliable (browser: IWebDriver) =
+    if browser = null then
+        raise
+            (CanopyNoBrowserException
+                ("Can't perform the action because the browser instance is null.  `start chrome` to start a new browser."))
+
     if canopy.configuration.wipTest then colorizeAndSleep cssSelector browser
 
     try
@@ -260,10 +299,9 @@ let private findByFunction cssSelector timeout waitFunc searchContext reliable (
             !elements
         else
             waitResults elementTimeout (fun _ -> waitFunc cssSelector searchContext browser)
-    with
-        | :? WebDriverTimeoutException ->
-            suggestOtherSelectors cssSelector browser
-            raise (CanopyElementNotFoundException(sprintf "can't find element %s" cssSelector))
+    with :? WebDriverTimeoutException ->
+        suggestOtherSelectors cssSelector browser
+        raise (CanopyElementNotFoundException(sprintf "can't find element %s" cssSelector))
 
 let private find cssSelector timeout searchContext reliable browser =
     (findByFunction cssSelector timeout findElements searchContext reliable browser).Head
@@ -276,17 +314,25 @@ let private findMany cssSelector timeout searchContext reliable browser =
 let private elementFromList cssSelector elementsList =
     match elementsList with
     | [] -> null
-    | x :: [] -> x
+    | [ x ] -> x
     | x :: y :: _ ->
-        if throwIfMoreThanOneElement then raise (CanopyMoreThanOneElementFoundException(sprintf "More than one element was selected when only one was expected for selector: %s" cssSelector))
+        if throwIfMoreThanOneElement then
+            raise
+                (CanopyMoreThanOneElementFoundException
+                    (sprintf "More than one element was selected when only one was expected for selector: %s"
+                         cssSelector))
         else x
 
 let private someElementFromList cssSelector elementsList =
     match elementsList with
     | [] -> None
-    | x :: [] -> Some(x)
+    | [ x ] -> Some(x)
     | x :: y :: _ ->
-        if throwIfMoreThanOneElement then raise (CanopyMoreThanOneElementFoundException(sprintf "More than one element was selected when only one was expected for selector: %s" cssSelector))
+        if throwIfMoreThanOneElement then
+            raise
+                (CanopyMoreThanOneElementFoundException
+                    (sprintf "More than one element was selected when only one was expected for selector: %s"
+                         cssSelector))
         else Some(x)
 
 (* documented/actions *)
@@ -302,12 +348,11 @@ let unreliableElements cssSelector browser = findMany cssSelector elementTimeout
 let unreliableElement cssSelector browser = unreliableElements cssSelector browser |> elementFromList cssSelector
 
 (* documented/actions *)
-let elementWithin cssSelector (elem:IWebElement) =  find cssSelector elementTimeout elem true
+let elementWithin cssSelector (elem: IWebElement) = find cssSelector elementTimeout elem true
 
 (* documented/actions *)
 let elementsWithText cssSelector regex browser =
-    unreliableElements cssSelector browser
-    |> List.filter (fun elem -> regexMatch regex (textOf elem))
+    unreliableElements cssSelector browser |> List.filter (fun elem -> regexMatch regex (textOf elem))
 
 (* documented/actions *)
 let elementWithText cssSelector regex browser = (elementsWithText cssSelector regex browser).Head
@@ -325,7 +370,8 @@ let unreliableElementsWithin cssSelector elem = findMany cssSelector elementTime
 let someElement cssSelector browser = unreliableElements cssSelector browser |> someElementFromList cssSelector
 
 (* documented/actions *)
-let someElementWithin cssSelector elem browser = unreliableElementsWithin cssSelector elem browser |> someElementFromList cssSelector
+let someElementWithin cssSelector elem browser =
+    unreliableElementsWithin cssSelector elem browser |> someElementFromList cssSelector
 
 (* documented/actions *)
 let someParent elem browser = elementsWithin ".." elem browser |> someElementFromList "provided element"
@@ -340,55 +386,66 @@ let first cssSelector browser = (elements cssSelector browser).Head
 let last cssSelector browser = (List.rev (elements cssSelector browser)).Head
 
 //read/write
-let private writeToSelect (elem:IWebElement) (text:string) browser =
-    let options = unreliableElementsWithin (sprintf """option[text()="%s"] | option[@value="%s"] | optgroup/option[text()="%s"] | optgroup/option[@value="%s"]""" text text text text) elem browser
-            
+let private writeToSelect (elem: IWebElement) (text: string) browser =
+    let options =
+        unreliableElementsWithin
+            (sprintf
+                """option[text()="%s"] | option[@value="%s"] | optgroup/option[text()="%s"] | optgroup/option[@value="%s"]"""
+                 text text text text) elem browser
+
     match options with
     | [] -> raise (CanopyOptionNotFoundException(sprintf "element %s does not contain value %s" (elem.ToString()) text))
-    | head::_ -> head.Click()
+    | head :: _ -> head.Click()
 
-let private writeToElement (e : IWebElement) (text:string) browser =
+let private writeToElement (e: IWebElement) (text: string) browser =
     if e.TagName = "select" then
         writeToSelect e text browser
     else
         let readonly = e.GetAttribute("readonly")
         if readonly = "true" then
-            raise (CanopyReadOnlyException(sprintf "element %s is marked as read only, you can not write to read only elements" (e.ToString())))
-        if not optimizeByDisablingClearBeforeWrite then try e.Clear() with ex -> ex |> ignore
+            raise
+                (CanopyReadOnlyException
+                    (sprintf "element %s is marked as read only, you can not write to read only elements" (e.ToString())))
+        if not optimizeByDisablingClearBeforeWrite then
+            try
+                e.Clear()
+            with ex -> ex |> ignore
         e.SendKeys(text)
 
 (* documented/actions *)
 let write item text browser =
     match box item with
-    | :? IWebElement as elem ->  writeToElement elem text browser
+    | :? IWebElement as elem -> writeToElement elem text browser
     | :? string as cssSelector ->
         wait elementTimeout (fun _ ->
             elements cssSelector browser
-                |> List.map (fun elem ->
-                    try
-                        writeToElement elem text browser
-                        true
-                    with
-                        //Note: Enrich exception with proper cssSelector description
-                        | :? CanopyReadOnlyException -> raise (CanopyReadOnlyException(sprintf "element %s is marked as read only, you can not write to read only elements" cssSelector))
-                        | _ -> false)
-                |> List.exists (fun elem -> elem = true)
-        )
+            |> List.map (fun elem ->
+                try
+                    writeToElement elem text browser
+                    true
+                with
+                //Note: Enrich exception with proper cssSelector description
+                | :? CanopyReadOnlyException ->
+                    raise
+                        (CanopyReadOnlyException
+                            (sprintf "element %s is marked as read only, you can not write to read only elements"
+                                 cssSelector))
+                | _ -> false)
+            |> List.exists (fun elem -> elem = true))
     | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't read %O because it is not a string or element" item))
 
 let private safeRead item browser =
     let readvalue = ref ""
     try
         wait elementTimeout (fun _ ->
-          readvalue :=
-            match box item with
-            | :? IWebElement as elem -> textOf elem
-            | :? string as cssSelector -> element cssSelector browser |> textOf
-            | _ -> raise (CanopyReadException("was unable to read item because it was not a string or IWebElement"))
-          true)
+            readvalue
+            := match box item with
+               | :? IWebElement as elem -> textOf elem
+               | :? string as cssSelector -> element cssSelector browser |> textOf
+               | _ -> raise (CanopyReadException("was unable to read item because it was not a string or IWebElement"))
+            true)
         !readvalue
-    with
-        | :? WebDriverTimeoutException -> raise (CanopyReadException("was unable to read item for unknown reason"))
+    with :? WebDriverTimeoutException -> raise (CanopyReadException("was unable to read item for unknown reason"))
 
 (* documented/actions *)
 let read item browser =
@@ -399,36 +456,48 @@ let read item browser =
 
 (* documented/actions *)
 let clear item browser =
-    let clear cssSelector (elem : IWebElement) =
+    let clear cssSelector (elem: IWebElement) =
         let readonly = elem.GetAttribute("readonly")
-        if readonly = "true" then raise (CanopyReadOnlyException(sprintf "element %s is marked as read only, you can not clear read only elements" cssSelector))
+        if readonly = "true" then
+            raise
+                (CanopyReadOnlyException
+                    (sprintf "element %s is marked as read only, you can not clear read only elements" cssSelector))
         elem.Clear()
 
     match box item with
     | :? IWebElement as elem -> clear elem.TagName elem
     | :? string as cssSelector -> element cssSelector browser |> clear cssSelector
-    | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't clear %O because it is not a string or element" item))
+    | _ ->
+        raise (CanopyNotStringOrElementException(sprintf "Can't clear %O because it is not a string or element" item))
 
 //status
 (* documented/assertions *)
 let selected item browser =
-    let selected cssSelector (elem : IWebElement) =
-        if not <| elem.Selected then raise (CanopySelectionFailedExeception(sprintf "element selected failed, %s not selected." cssSelector))
+    let selected cssSelector (elem: IWebElement) =
+        if not <| elem.Selected then
+            raise (CanopySelectionFailedExeception(sprintf "element selected failed, %s not selected." cssSelector))
 
     match box item with
     | :? IWebElement as elem -> selected elem.TagName elem
     | :? string as cssSelector -> element cssSelector browser |> selected cssSelector
-    | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't check selected on %O because it is not a string or element" item))
+    | _ ->
+        raise
+            (CanopyNotStringOrElementException
+                (sprintf "Can't check selected on %O because it is not a string or element" item))
 
 (* documented/assertions *)
 let deselected item browser =
-    let deselected cssSelector (elem : IWebElement) =
-        if elem.Selected then raise (CanopyDeselectionFailedException(sprintf "element deselected failed, %s selected." cssSelector))
+    let deselected cssSelector (elem: IWebElement) =
+        if elem.Selected then
+            raise (CanopyDeselectionFailedException(sprintf "element deselected failed, %s selected." cssSelector))
 
     match box item with
     | :? IWebElement as elem -> deselected elem.TagName elem
     | :? string as cssSelector -> element cssSelector browser |> deselected cssSelector
-    | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't check deselected on %O because it is not a string or element" item))
+    | _ ->
+        raise
+            (CanopyNotStringOrElementException
+                (sprintf "Can't check deselected on %O because it is not a string or element" item))
 
 //keyboard
 (* documented/actions *)
@@ -453,34 +522,36 @@ let press key browser =
 
 //alerts
 (* documented/actions *)
-let alert (browser : IWebDriver) =
+let alert (browser: IWebDriver) =
     waitFor (fun _ ->
         browser.SwitchTo().Alert() |> ignore
         true)
     browser.SwitchTo().Alert()
 
 (* documented/actions *)
-let acceptAlert (browser : IWebDriver) =
+let acceptAlert (browser: IWebDriver) =
     wait compareTimeout (fun _ ->
         browser.SwitchTo().Alert().Accept()
         true)
 
 (* documented/actions *)
-let dismissAlert (browser : IWebDriver) =
+let dismissAlert (browser: IWebDriver) =
     wait compareTimeout (fun _ ->
         browser.SwitchTo().Alert().Dismiss()
         true)
 
 (* documented/actions *)
 let fastTextFromCSS selector browser =
-  let script =
-    //there is no map on NodeList which is the type returned by querySelectorAll =(
-    sprintf """return [].map.call(document.querySelectorAll("%s"), function (item) { return item.text || item.innerText; });""" selector
-  try
-    js script browser :?> System.Collections.ObjectModel.ReadOnlyCollection<System.Object>
-    |> Seq.map (fun item -> item.ToString())
-    |> List.ofSeq
-  with | _ -> [ "default" ]
+    let script =
+        //there is no map on NodeList which is the type returned by querySelectorAll =(
+        sprintf
+            """return [].map.call(document.querySelectorAll("%s"), function (item) { return item.text || item.innerText; });"""
+            selector
+    try
+        js script browser :?> System.Collections.ObjectModel.ReadOnlyCollection<System.Object>
+        |> Seq.map (fun item -> item.ToString())
+        |> List.ofSeq
+    with _ -> [ "default" ]
 
 //assertions
 (* documented/assertions *)
@@ -494,59 +565,89 @@ let equals item value browser =
     | :? string as cssSelector ->
         let bestvalue = ref ""
         try
-            wait compareTimeout (fun _ -> ( let readvalue = read cssSelector browser
-                                            if readvalue <> value && readvalue <> "" then
-                                                bestvalue := readvalue
-                                                false
-                                            else
-                                                readvalue = value))
+            wait compareTimeout (fun _ ->
+                (let readvalue = read cssSelector browser
+                 if readvalue <> value && readvalue <> "" then
+                     bestvalue := readvalue
+                     false
+                 else
+                     readvalue = value))
         with
-            | :? CanopyElementNotFoundException as ex -> raise (CanopyEqualityFailedException(sprintf "%s%sequality check failed.  expected: %s, got: %s" ex.Message Environment.NewLine value !bestvalue))
-            | :? WebDriverTimeoutException -> raise (CanopyEqualityFailedException(sprintf "equality check failed.  expected: %s, got: %s" value !bestvalue))
+        | :? CanopyElementNotFoundException as ex ->
+            raise
+                (CanopyEqualityFailedException
+                    (sprintf "%s%sequality check failed.  expected: %s, got: %s" ex.Message Environment.NewLine value
+                         !bestvalue))
+        | :? WebDriverTimeoutException ->
+            raise
+                (CanopyEqualityFailedException(sprintf "equality check failed.  expected: %s, got: %s" value !bestvalue))
 
-    | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't check equality on %O because it is not a string or alert" item))
+    | _ ->
+        raise
+            (CanopyNotStringOrElementException
+                (sprintf "Can't check equality on %O because it is not a string or alert" item))
 
 (* documented/assertions *)
 let notEquals cssSelector value browser =
     try
         wait compareTimeout (fun _ -> (read cssSelector browser) <> value)
     with
-        | :? CanopyElementNotFoundException as ex -> raise (CanopyNotEqualsFailedException(sprintf "%s%snot equals check failed.  expected NOT: %s, got: " ex.Message Environment.NewLine value))
-        | :? WebDriverTimeoutException -> raise (CanopyNotEqualsFailedException(sprintf "not equals check failed.  expected NOT: %s, got: %s" value (read cssSelector browser)))
+    | :? CanopyElementNotFoundException as ex ->
+        raise
+            (CanopyNotEqualsFailedException
+                (sprintf "%s%snot equals check failed.  expected NOT: %s, got: " ex.Message Environment.NewLine value))
+    | :? WebDriverTimeoutException ->
+        raise
+            (CanopyNotEqualsFailedException
+                (sprintf "not equals check failed.  expected NOT: %s, got: %s" value (read cssSelector browser)))
 
 (* documented/assertions *)
 let oneOrManyEquals cssSelector value browser =
     try
-        wait compareTimeout (fun _ -> (elements cssSelector browser |> Seq.exists(fun element -> (textOf element) = value)))
+        wait compareTimeout
+            (fun _ -> (elements cssSelector browser |> Seq.exists (fun element -> (textOf element) = value)))
     with
-        | :? CanopyElementNotFoundException as ex -> raise (CanopyValueNotInListException(sprintf "%s%scan't find %s in list %s%sgot: " ex.Message Environment.NewLine value cssSelector Environment.NewLine))
-        | :? WebDriverTimeoutException ->
-            let sb = new System.Text.StringBuilder()
-            elements cssSelector browser |> List.iter (fun e -> bprintf sb "%s%s" (textOf e) Environment.NewLine)
-            raise (CanopyValueNotInListException(sprintf "can't find %s in list %s%sgot: %s" value cssSelector Environment.NewLine (sb.ToString())))
+    | :? CanopyElementNotFoundException as ex ->
+        raise
+            (CanopyValueNotInListException
+                (sprintf "%s%scan't find %s in list %s%sgot: " ex.Message Environment.NewLine value cssSelector
+                     Environment.NewLine))
+    | :? WebDriverTimeoutException ->
+        let sb = System.Text.StringBuilder()
+        elements cssSelector browser |> List.iter (fun e -> bprintf sb "%s%s" (textOf e) Environment.NewLine)
+        raise
+            (CanopyValueNotInListException
+                (sprintf "can't find %s in list %s%sgot: %s" value cssSelector Environment.NewLine (sb.ToString())))
 
 (* documented/assertions *)
 let noneOfManyNotEquals cssSelector value browser =
     try
-        wait compareTimeout (fun _ -> (elements cssSelector browser |> Seq.exists(fun element -> (textOf element) = value) |> not))
+        wait compareTimeout (fun _ ->
+            (elements cssSelector browser
+             |> Seq.exists (fun element -> (textOf element) = value)
+             |> not))
     with
-        | :? CanopyElementNotFoundException as ex -> raise (CanopyValueInListException(sprintf "%s%sfound check failed" ex.Message Environment.NewLine))
-        | :? WebDriverTimeoutException -> raise (CanopyValueInListException(sprintf "found %s in list %s, expected not to" value cssSelector))
+    | :? CanopyElementNotFoundException as ex ->
+        raise (CanopyValueInListException(sprintf "%s%sfound check failed" ex.Message Environment.NewLine))
+    | :? WebDriverTimeoutException ->
+        raise (CanopyValueInListException(sprintf "found %s in list %s, expected not to" value cssSelector))
 
 (* documented/assertions *)
-let contains (value1 : string) (value2 : string) =
-    if (value2.Contains(value1) <> true) then
+let contains (value1: string) (value2: string) =
+    if not (value2.Contains(value1)) then
         raise (CanopyContainsFailedException(sprintf "contains check failed.  %s does not contain %s" value2 value1))
 
 (* documented/assertions *)
-let containsInsensitive (value1 : string) (value2 : string) =
+let containsInsensitive (value1: string) (value2: string) =
     let rules = StringComparison.InvariantCultureIgnoreCase
     let contains = value2.IndexOf(value1, rules)
     if contains < 0 then
-        raise (CanopyContainsFailedException(sprintf "contains insensitive check failed.  %s does not contain %s" value2 value1))
+        raise
+            (CanopyContainsFailedException
+                (sprintf "contains insensitive check failed.  %s does not contain %s" value2 value1))
 
 (* documented/assertions *)
-let notContains (value1 : string) (value2 : string) =
+let notContains (value1: string) (value2: string) =
     if (value2.Contains(value1) = true) then
         raise (CanopyNotContainsFailedException(sprintf "notContains check failed.  %s does contain %s" value2 value1))
 
@@ -555,35 +656,63 @@ let count cssSelector count browser =
     try
         wait compareTimeout (fun _ -> (unreliableElements cssSelector browser).Length = count)
     with
-        | :? CanopyElementNotFoundException as ex -> raise (CanopyCountException(sprintf "%s%scount failed. expected: %i got: %i" ex.Message Environment.NewLine count 0))
-        | :? WebDriverTimeoutException -> raise (CanopyCountException(sprintf "count failed. expected: %i got: %i" count (unreliableElements cssSelector browser).Length))
+    | :? CanopyElementNotFoundException as ex ->
+        raise
+            (CanopyCountException
+                (sprintf "%s%scount failed. expected: %i got: %i" ex.Message Environment.NewLine count 0))
+    | :? WebDriverTimeoutException ->
+        raise
+            (CanopyCountException
+                (sprintf "count failed. expected: %i got: %i" count (unreliableElements cssSelector browser).Length))
 
 (* documented/assertions *)
 let regexEquals cssSelector pattern browser =
     try
         wait compareTimeout (fun _ -> regexMatch pattern (read cssSelector browser))
     with
-        | :? CanopyElementNotFoundException as ex -> raise (CanopyEqualityFailedException(sprintf "%s%sregex equality check failed.  expected: %s, got:" ex.Message Environment.NewLine pattern))
-        | :? WebDriverTimeoutException -> raise (CanopyEqualityFailedException(sprintf "regex equality check failed.  expected: %s, got: %s" pattern (read cssSelector browser)))
+    | :? CanopyElementNotFoundException as ex ->
+        raise
+            (CanopyEqualityFailedException
+                (sprintf "%s%sregex equality check failed.  expected: %s, got:" ex.Message Environment.NewLine pattern))
+    | :? WebDriverTimeoutException ->
+        raise
+            (CanopyEqualityFailedException
+                (sprintf "regex equality check failed.  expected: %s, got: %s" pattern (read cssSelector browser)))
 
 (* documented/assertions *)
 let regexNotEquals cssSelector pattern browser =
     try
         wait compareTimeout (fun _ -> regexMatch pattern (read cssSelector browser) |> not)
     with
-        | :? CanopyElementNotFoundException as ex -> raise (CanopyEqualityFailedException(sprintf "%s%sregex not equality check failed.  expected NOT: %s, got:" ex.Message Environment.NewLine pattern))
-        | :? WebDriverTimeoutException -> raise (CanopyEqualityFailedException(sprintf "regex not equality check failed.  expected NOT: %s, got: %s" pattern (read cssSelector browser)))
+    | :? CanopyElementNotFoundException as ex ->
+        raise
+            (CanopyEqualityFailedException
+                (sprintf "%s%sregex not equality check failed.  expected NOT: %s, got:" ex.Message Environment.NewLine
+                     pattern))
+    | :? WebDriverTimeoutException ->
+        raise
+            (CanopyEqualityFailedException
+                (sprintf "regex not equality check failed.  expected NOT: %s, got: %s" pattern
+                     (read cssSelector browser)))
 
 (* documented/assertions *)
 let oneOrManyRegexEquals cssSelector pattern browser =
     try
-        wait compareTimeout (fun _ -> (elements cssSelector browser |> Seq.exists(fun element -> regexMatch pattern (textOf element))))
+        wait compareTimeout
+            (fun _ -> (elements cssSelector browser |> Seq.exists (fun element -> regexMatch pattern (textOf element))))
     with
-        | :? CanopyElementNotFoundException as ex -> raise (CanopyValueNotInListException(sprintf "%s%scan't regex find %s in list %s%sgot: " ex.Message Environment.NewLine pattern cssSelector Environment.NewLine))
-        | :? WebDriverTimeoutException ->
-            let sb = new System.Text.StringBuilder()
-            elements cssSelector browser |> List.iter (fun e -> bprintf sb "%s%s" (textOf e) Environment.NewLine)
-            raise (CanopyValueNotInListException(sprintf "can't regex find %s in list %s%sgot: %s" pattern cssSelector Environment.NewLine (sb.ToString())))
+    | :? CanopyElementNotFoundException as ex ->
+        raise
+            (CanopyValueNotInListException
+                (sprintf "%s%scan't regex find %s in list %s%sgot: " ex.Message Environment.NewLine pattern cssSelector
+                     Environment.NewLine))
+    | :? WebDriverTimeoutException ->
+        let sb = System.Text.StringBuilder()
+        elements cssSelector browser |> List.iter (fun e -> bprintf sb "%s%s" (textOf e) Environment.NewLine)
+        raise
+            (CanopyValueNotInListException
+                (sprintf "can't regex find %s in list %s%sgot: %s" pattern cssSelector Environment.NewLine
+                     (sb.ToString())))
 
 (* documented/assertions *)
 let is expected actual =
@@ -593,7 +722,7 @@ let is expected actual =
 (* documented/assertions *)
 let (===) expected actual = is expected actual
 
-let private shown (elem : IWebElement) =
+let private shown (elem: IWebElement) =
     let opacity = elem.GetCssValue("opacity")
     let display = elem.GetCssValue("display")
     display <> "none" && opacity = "1"
@@ -601,50 +730,83 @@ let private shown (elem : IWebElement) =
 (* documented/assertions *)
 let displayed item browser =
     try
-        wait compareTimeout (fun _ ->
+        wait compareTimeout
+            (fun _ ->
             match box item with
-            | :? IWebElement as element ->  shown element
+            | :? IWebElement as element -> shown element
             | :? string as cssSelector -> element cssSelector browser |> shown
-            | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't check displayed on %O because it is not a string or webelement" item)))
+            | _ ->
+                raise
+                    (CanopyNotStringOrElementException
+                        (sprintf "Can't check displayed on %O because it is not a string or webelement" item)))
     with
-        | :? CanopyElementNotFoundException as ex -> raise (CanopyDisplayedFailedException(sprintf "%s%sdisplay check for %O failed." ex.Message Environment.NewLine item))
-        | :? WebDriverTimeoutException -> raise (CanopyDisplayedFailedException(sprintf "display check for %O failed." item))
+    | :? CanopyElementNotFoundException as ex ->
+        raise
+            (CanopyDisplayedFailedException
+                (sprintf "%s%sdisplay check for %O failed." ex.Message Environment.NewLine item))
+    | :? WebDriverTimeoutException ->
+        raise (CanopyDisplayedFailedException(sprintf "display check for %O failed." item))
 
 (* documented/assertions *)
 let notDisplayed item browser =
     try
-        wait compareTimeout (fun _ ->
+        wait compareTimeout
+            (fun _ ->
             match box item with
-            | :? IWebElement as element -> not(shown element)
-            | :? string as cssSelector -> (unreliableElements cssSelector browser |> List.isEmpty) || not(unreliableElement cssSelector browser |> shown)
-            | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't check notDisplayed on %O because it is not a string or webelement" item)))
+            | :? IWebElement as element -> not (shown element)
+            | :? string as cssSelector ->
+                (unreliableElements cssSelector browser |> List.isEmpty)
+                || not (unreliableElement cssSelector browser |> shown)
+            | _ ->
+                raise
+                    (CanopyNotStringOrElementException
+                        (sprintf "Can't check notDisplayed on %O because it is not a string or webelement" item)))
     with
-        | :? CanopyElementNotFoundException as ex -> raise (CanopyNotDisplayedFailedException(sprintf "%s%snotDisplay check for %O failed." ex.Message Environment.NewLine item))
-        | :? WebDriverTimeoutException -> raise (CanopyNotDisplayedFailedException(sprintf "notDisplay check for %O failed." item))
+    | :? CanopyElementNotFoundException as ex ->
+        raise
+            (CanopyNotDisplayedFailedException
+                (sprintf "%s%snotDisplay check for %O failed." ex.Message Environment.NewLine item))
+    | :? WebDriverTimeoutException ->
+        raise (CanopyNotDisplayedFailedException(sprintf "notDisplay check for %O failed." item))
 
 (* documented/assertions *)
 let enabled item browser =
     try
-        wait compareTimeout (fun _ ->
+        wait compareTimeout
+            (fun _ ->
             match box item with
             | :? IWebElement as element -> element.Enabled = true
             | :? string as cssSelector -> (element cssSelector browser).Enabled = true
-            | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't check enabled on %O because it is not a string or webelement" item)))
+            | _ ->
+                raise
+                    (CanopyNotStringOrElementException
+                        (sprintf "Can't check enabled on %O because it is not a string or webelement" item)))
     with
-        | :? CanopyElementNotFoundException as ex -> raise (CanopyEnabledFailedException(sprintf "%s%senabled check for %O failed." ex.Message Environment.NewLine item))
-        | :? WebDriverTimeoutException -> raise (CanopyEnabledFailedException(sprintf "enabled check for %O failed." item))
+    | :? CanopyElementNotFoundException as ex ->
+        raise
+            (CanopyEnabledFailedException
+                (sprintf "%s%senabled check for %O failed." ex.Message Environment.NewLine item))
+    | :? WebDriverTimeoutException -> raise (CanopyEnabledFailedException(sprintf "enabled check for %O failed." item))
 
 (* documented/assertions *)
 let disabled item browser =
     try
-        wait compareTimeout (fun _ ->
+        wait compareTimeout
+            (fun _ ->
             match box item with
             | :? IWebElement as element -> element.Enabled = false
             | :? string as cssSelector -> (element cssSelector browser).Enabled = false
-            | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't check disabled on %O because it is not a string or webelement" item)))
+            | _ ->
+                raise
+                    (CanopyNotStringOrElementException
+                        (sprintf "Can't check disabled on %O because it is not a string or webelement" item)))
     with
-        | :? CanopyElementNotFoundException as ex -> raise (CanopyDisabledFailedException(sprintf "%s%sdisabled check for %O failed." ex.Message Environment.NewLine item))
-        | :? WebDriverTimeoutException -> raise (CanopyDisabledFailedException(sprintf "disabled check for %O failed." item))
+    | :? CanopyElementNotFoundException as ex ->
+        raise
+            (CanopyDisabledFailedException
+                (sprintf "%s%sdisabled check for %O failed." ex.Message Environment.NewLine item))
+    | :? WebDriverTimeoutException ->
+        raise (CanopyDisabledFailedException(sprintf "disabled check for %O failed." item))
 
 (* documented/assertions *)
 let fadedIn cssSelector browser = fun _ -> element cssSelector browser |> shown
@@ -662,85 +824,112 @@ let click item browser =
                 try
                     elem.Click()
                     atleastOneItemClicked := true
-                with | ex -> ())
+                with ex -> ())
             !atleastOneItemClicked)
-    | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't click %O because it is not a string or webelement" item))
+    | _ ->
+        raise
+            (CanopyNotStringOrElementException(sprintf "Can't click %O because it is not a string or webelement" item))
 
 (* documented/actions *)
-let doubleClick item (browser : IWebDriver) =
-    let js = "var evt = document.createEvent('MouseEvents'); evt.initMouseEvent('dblclick',true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0,null); arguments[0].dispatchEvent(evt);"
+let doubleClick item (browser: IWebDriver) =
+    let js =
+        "var evt = document.createEvent('MouseEvents'); evt.initMouseEvent('dblclick',true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0,null); arguments[0].dispatchEvent(evt);"
 
     match box item with
     | :? IWebElement as elem -> (browser :?> IJavaScriptExecutor).ExecuteScript(js, elem) |> ignore
     | :? string as cssSelector ->
-        wait elementTimeout (fun _ -> ( let elem = element cssSelector browser
-                                        (browser :?> IJavaScriptExecutor).ExecuteScript(js, elem) |> ignore
-                                        true))
-    | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't doubleClick %O because it is not a string or webelement" item))
+        wait elementTimeout (fun _ ->
+            (let elem = element cssSelector browser
+             (browser :?> IJavaScriptExecutor).ExecuteScript(js, elem) |> ignore
+             true))
+    | _ ->
+        raise
+            (CanopyNotStringOrElementException
+                (sprintf "Can't doubleClick %O because it is not a string or webelement" item))
 
 (* documented/actions *)
 let ctrlClick item browser =
-        let actions = Actions(browser)
+    let actions = Actions(browser)
 
-        match box item with
-        | :? IWebElement as elem -> actions.KeyDown(Keys.Control).Click(elem).KeyUp(Keys.Control).Perform() |> ignore
-        | :? string as cssSelector ->
-        wait elementTimeout (fun _ -> ( let elem = element cssSelector browser
-                                        actions.KeyDown(Keys.Control).Click(elem).KeyUp(Keys.Control).Perform()
-                                        true))
-        | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't ctrlClick %O because it is not a string or webelement" item))
+    match box item with
+    | :? IWebElement as elem -> actions.KeyDown(Keys.Control).Click(elem).KeyUp(Keys.Control).Perform() |> ignore
+    | :? string as cssSelector ->
+        wait elementTimeout (fun _ ->
+            (let elem = element cssSelector browser
+             actions.KeyDown(Keys.Control).Click(elem).KeyUp(Keys.Control).Perform()
+             true))
+    | _ ->
+        raise
+            (CanopyNotStringOrElementException
+                (sprintf "Can't ctrlClick %O because it is not a string or webelement" item))
 
 (* documented/actions *)
 let shiftClick item browser =
-        let actions = Actions(browser)
+    let actions = Actions(browser)
 
-        match box item with
-        | :? IWebElement as elem -> actions.KeyDown(Keys.Shift).Click(elem).KeyUp(Keys.Shift).Perform() |> ignore
-        | :? string as cssSelector ->
-        wait elementTimeout (fun _ -> ( let elem = element cssSelector browser
-                                        actions.KeyDown(Keys.Shift).Click(elem).KeyUp(Keys.Shift).Perform()
-                                        true))
-        | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't shiftClick %O because it is not a string or webelement" item))
+    match box item with
+    | :? IWebElement as elem -> actions.KeyDown(Keys.Shift).Click(elem).KeyUp(Keys.Shift).Perform() |> ignore
+    | :? string as cssSelector ->
+        wait elementTimeout (fun _ ->
+            (let elem = element cssSelector browser
+             actions.KeyDown(Keys.Shift).Click(elem).KeyUp(Keys.Shift).Perform()
+             true))
+    | _ ->
+        raise
+            (CanopyNotStringOrElementException
+                (sprintf "Can't shiftClick %O because it is not a string or webelement" item))
 
 (* documented/actions *)
 let rightClick item browser =
-        let actions = Actions(browser)
+    let actions = Actions(browser)
 
-        match box item with
-        | :? IWebElement as elem -> actions.ContextClick(elem).Perform() |> ignore
-        | :? string as cssSelector ->
-        wait elementTimeout (fun _ -> ( let elem = element cssSelector browser
-                                        actions.ContextClick(elem).Perform()
-                                        true))
-        | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't rightClick %O because it is not a string or webelement" item))
+    match box item with
+    | :? IWebElement as elem -> actions.ContextClick(elem).Perform() |> ignore
+    | :? string as cssSelector ->
+        wait elementTimeout (fun _ ->
+            (let elem = element cssSelector browser
+             actions.ContextClick(elem).Perform()
+             true))
+    | _ ->
+        raise
+            (CanopyNotStringOrElementException
+                (sprintf "Can't rightClick %O because it is not a string or webelement" item))
 
 (* documented/actions *)
 let check item browser =
     try
         match box item with
-        | :? IWebElement as elem -> if not <| elem.Selected then click elem browser
+        | :? IWebElement as elem ->
+            if not <| elem.Selected then click elem browser
         | :? string as cssSelector ->
             waitFor (fun _ ->
                 if not <| (element cssSelector browser).Selected then click cssSelector browser
                 (element cssSelector browser).Selected)
-        | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't read %O because it is not a string or element" item))
+        | _ ->
+            raise
+                (CanopyNotStringOrElementException(sprintf "Can't read %O because it is not a string or element" item))
     with
-        | :? CanopyElementNotFoundException as ex -> raise (CanopyCheckFailedException(sprintf "%s%sfailed to check %O." ex.Message Environment.NewLine item))
-        | :? WebDriverTimeoutException -> raise (CanopyCheckFailedException(sprintf "failed to check %O." item))
+    | :? CanopyElementNotFoundException as ex ->
+        raise (CanopyCheckFailedException(sprintf "%s%sfailed to check %O." ex.Message Environment.NewLine item))
+    | :? WebDriverTimeoutException -> raise (CanopyCheckFailedException(sprintf "failed to check %O." item))
 
 (* documented/actions *)
 let uncheck item browser =
     try
         match box item with
-        | :? IWebElement as elem -> if elem.Selected then click elem browser
+        | :? IWebElement as elem ->
+            if elem.Selected then click elem browser
         | :? string as cssSelector ->
             waitFor (fun _ ->
                 if (element cssSelector browser).Selected then click cssSelector browser
                 (element cssSelector browser).Selected = false)
-        | _ -> raise (CanopyNotStringOrElementException(sprintf "Can't read %O because it is not a string or element" item))
+        | _ ->
+            raise
+                (CanopyNotStringOrElementException(sprintf "Can't read %O because it is not a string or element" item))
     with
-        | :? CanopyElementNotFoundException as ex -> raise (CanopyUncheckFailedException(sprintf "%s%sfailed to uncheck %O." ex.Message Environment.NewLine item))
-        | :? WebDriverTimeoutException -> raise (CanopyUncheckFailedException(sprintf "failed to uncheck %O." item))
+    | :? CanopyElementNotFoundException as ex ->
+        raise (CanopyUncheckFailedException(sprintf "%s%sfailed to uncheck %O." ex.Message Environment.NewLine item))
+    | :? WebDriverTimeoutException -> raise (CanopyUncheckFailedException(sprintf "failed to uncheck %O." item))
 
 //hoverin
 (* documented/actions *)
@@ -755,18 +944,18 @@ let drag cssSelectorA cssSelectorB browser =
     wait elementTimeout (fun _ ->
         let a = element cssSelectorA browser
         let b = element cssSelectorB browser
-        (new Actions(browser)).DragAndDrop(a, b).Perform()
+        (Actions(browser)).DragAndDrop(a, b).Perform()
         true)
 
 //browser related
 (* documented/actions *)
-let pin direction (browser : IWebDriver) =
-    let (w, h) = canopy.screen.getPrimaryScreenResolution ()
+let pin direction (browser: IWebDriver) =
+    let (w, h) = canopy.screen.getPrimaryScreenResolution()
     let maxWidth = w / 2
-    browser.Manage().Window.Size <- new System.Drawing.Size(maxWidth, h)
+    browser.Manage().Window.Size <- System.Drawing.Size(maxWidth, h)
     match direction with
-    | Left -> browser.Manage().Window.Position <- new System.Drawing.Point((maxWidth * 0), 0)
-    | Right -> browser.Manage().Window.Position <- new System.Drawing.Point((maxWidth * 1), 0)
+    | Left -> browser.Manage().Window.Position <- System.Drawing.Point(0, 0)
+    | Right -> browser.Manage().Window.Position <- System.Drawing.Point(maxWidth, 0)
     | FullScreen -> browser.Manage().Window.Maximize()
 
 let private firefoxDriverService _ =
@@ -776,17 +965,23 @@ let private firefoxDriverService _ =
     service.HideCommandPromptWindow <- hideCommandPromptWindow
     service
 
-let private firefoxWithUserAgent (userAgent : string) =
+let private firefoxWithUserAgent (userAgent: string) =
     let profile = FirefoxProfile()
     profile.SetPreference("general.useragent.override", userAgent)
-    let options = Firefox.FirefoxOptions();
+    let options = Firefox.FirefoxOptions()
     options.Profile <- profile
-    new FirefoxDriver(firefoxDriverService (), options, TimeSpan.FromSeconds(20.0)) :> IWebDriver
+    new FirefoxDriver(firefoxDriverService(), options, TimeSpan.FromSeconds(20.0)) :> IWebDriver
 
-let private chromeDriverService dir = 
-    let service = Chrome.ChromeDriverService.CreateDefaultService(dir);
+let private chromeDriverService dir =
+    let service = Chrome.ChromeDriverService.CreateDefaultService(dir)
     service.HostName <- driverHostName
-    service.HideCommandPromptWindow <- hideCommandPromptWindow;
+    service.HideCommandPromptWindow <- hideCommandPromptWindow
+    match acceptInsecureSslCerts with
+    | false -> ()
+    | true -> service.WhitelistedIPAddresses <- ""
+    match webdriverPort with
+    | Some value -> service.Port <- value
+    | None -> ()
     service
 
 let private chromeWithUserAgent dir userAgent =
@@ -794,19 +989,19 @@ let private chromeWithUserAgent dir userAgent =
     options.AddArgument("--user-agent=" + userAgent)
     new Chrome.ChromeDriver(chromeDriverService dir, options) :> IWebDriver
 
-let private ieDriverService _ = 
+let private ieDriverService _ =
     let service = IE.InternetExplorerDriverService.CreateDefaultService(ieDir)
     service.HostName <- driverHostName
     service.HideCommandPromptWindow <- hideCommandPromptWindow
     service
 
-let private edgeDriverService _ = 
+let private edgeDriverService _ =
     let service = Edge.EdgeDriverService.CreateDefaultService(edgeDir)
     service.HostName <- driverHostName
     service.HideCommandPromptWindow <- hideCommandPromptWindow
     service
 
-let private safariDriverService _ = 
+let private safariDriverService _ =
     let service = Safari.SafariDriverService.CreateDefaultService(safariDir)
     service.HostName <- driverHostName
     service.HideCommandPromptWindow <- hideCommandPromptWindow
@@ -823,21 +1018,20 @@ let start b =
 
     let browser =
         match b with
-        | IE -> new IE.InternetExplorerDriver(ieDriverService ()) :> IWebDriver
-        | IEWithOptions options -> new IE.InternetExplorerDriver(ieDriverService (), options) :> IWebDriver
-        | IEWithOptionsAndTimeSpan(options, timeSpan) -> new IE.InternetExplorerDriver(ieDriverService (), options, timeSpan) :> IWebDriver
-        | EdgeBETA -> new Edge.EdgeDriver(edgeDriverService ()) :> IWebDriver
+        | IE -> new IE.InternetExplorerDriver(ieDriverService()) :> IWebDriver
+        | IEWithOptions options -> new IE.InternetExplorerDriver(ieDriverService(), options) :> IWebDriver
+        | IEWithOptionsAndTimeSpan(options, timeSpan) ->
+            new IE.InternetExplorerDriver(ieDriverService(), options, timeSpan) :> IWebDriver
+        | EdgeBETA -> new Edge.EdgeDriver(edgeDriverService()) :> IWebDriver
         | Chrome ->
             let options = Chrome.ChromeOptions()
             options.AddArgument("--disable-extensions")
             options.AddArgument("disable-infobars")
             options.AddArgument("test-type") //https://code.google.com/p/chromedriver/issues/detail?id=799
             new Chrome.ChromeDriver(chromeDriverService chromeDir, options) :> IWebDriver
-        | ChromeWithOptions options ->
-            new Chrome.ChromeDriver(chromeDriverService chromeDir, options) :> IWebDriver
-        | ChromeWithUserAgent userAgent -> 
-            chromeWithUserAgent chromeDir userAgent
-        | ChromeWithOptionsAndTimeSpan(options, timeSpan) -> 
+        | ChromeWithOptions options -> new Chrome.ChromeDriver(chromeDriverService chromeDir, options) :> IWebDriver
+        | ChromeWithUserAgent userAgent -> chromeWithUserAgent chromeDir userAgent
+        | ChromeWithOptionsAndTimeSpan(options, timeSpan) ->
             new Chrome.ChromeDriver(chromeDriverService chromeDir, options, timeSpan) :> IWebDriver
         | ChromeHeadless ->
             let options = Chrome.ChromeOptions()
@@ -850,43 +1044,44 @@ let start b =
             let options = Chrome.ChromeOptions()
             options.AddArgument("--disable-extensions")
             options.AddArgument("disable-infobars")
-            options.AddArgument("test-type") //https://code.google.com/p/chromedriver/issues/detail?id=799            
+            options.AddArgument("test-type") //https://code.google.com/p/chromedriver/issues/detail?id=799
             new Chrome.ChromeDriver(chromeDriverService chromiumDir, options) :> IWebDriver
         | ChromiumWithOptions options ->
             new Chrome.ChromeDriver(chromeDriverService chromiumDir, options) :> IWebDriver
-        | Firefox ->new FirefoxDriver(firefoxDriverService ()) :> IWebDriver
-        | FirefoxWithPath path -> 
-          let options = new Firefox.FirefoxOptions()
-          options.BrowserExecutableLocation <- path
-          new FirefoxDriver(firefoxDriverService (), options, TimeSpan.FromSeconds(elementTimeout)) :> IWebDriver
+        | Firefox -> new FirefoxDriver(firefoxDriverService()) :> IWebDriver
+        | FirefoxWithPath path ->
+            let options = Firefox.FirefoxOptions()
+            options.BrowserExecutableLocation <- path
+            new FirefoxDriver(firefoxDriverService(), options, TimeSpan.FromSeconds(elementTimeout)) :> IWebDriver
         | FirefoxWithUserAgent userAgent -> firefoxWithUserAgent userAgent
         | FirefoxWithOptions options ->
-            new FirefoxDriver(firefoxDriverService (), options, TimeSpan.FromSeconds(elementTimeout)) :> IWebDriver
-        | FirefoxWithPathAndTimeSpan(path, timespan) -> 
-          let options = new Firefox.FirefoxOptions()
-          options.BrowserExecutableLocation <- path
-          new FirefoxDriver(firefoxDriverService (), options, timespan) :> IWebDriver
-        | FirefoxWithProfileAndTimeSpan(profile, timespan) -> 
-          let options = new Firefox.FirefoxOptions()
-          options.Profile <- profile
-          new FirefoxDriver(firefoxDriverService (), options, timespan) :> IWebDriver
-        | FirefoxHeadless -> 
-            let options = new Firefox.FirefoxOptions();
+            new FirefoxDriver(firefoxDriverService(), options, TimeSpan.FromSeconds(elementTimeout)) :> IWebDriver
+        | FirefoxWithPathAndTimeSpan(path, timespan) ->
+            let options = Firefox.FirefoxOptions()
+            options.BrowserExecutableLocation <- path
+            new FirefoxDriver(firefoxDriverService(), options, timespan) :> IWebDriver
+        | FirefoxWithProfileAndTimeSpan(profile, timespan) ->
+            let options = Firefox.FirefoxOptions()
+            options.Profile <- profile
+            new FirefoxDriver(firefoxDriverService(), options, timespan) :> IWebDriver
+        | FirefoxHeadless ->
+            let options = Firefox.FirefoxOptions()
             options.AddArgument("--headless")
-            new FirefoxDriver(firefoxDriverService (), options, TimeSpan.FromSeconds(elementTimeout)) :> IWebDriver
-        | Safari ->
-            new Safari.SafariDriver(safariDriverService ()) :> IWebDriver
-        | Remote(url, capabilities) -> new Remote.RemoteWebDriver(new Uri(url), capabilities) :> IWebDriver
+            new FirefoxDriver(firefoxDriverService(), options, TimeSpan.FromSeconds(elementTimeout)) :> IWebDriver
+        | Safari -> new Safari.SafariDriver(safariDriverService()) :> IWebDriver
+        | Remote(url, capabilities) -> new Remote.RemoteWebDriver(Uri(url), capabilities) :> IWebDriver
 
-    if autoPinBrowserRightOnLaunch = true then pin Right browser
+    if autoPinBrowserRightOnLaunch then pin Right browser
     browser
 
 (* documented/actions *)
-let switchToTab number (browser : IWebDriver) =
+let switchToTab number (browser: IWebDriver) =
     wait pageTimeout (fun _ ->
         let number = number - 1
-        let tabs = browser.WindowHandles;
-        if tabs |> Seq.length >= number then
+        let tabs = browser.WindowHandles
+        if tabs
+           |> Seq.length
+           >= number then
             browser.SwitchTo().Window(tabs.[number]) |> ignore
             true
         else
@@ -898,45 +1093,45 @@ let closeTab number browser =
     browser.Close()
 
 (* documented/actions *)
-let tile (browsers : IWebDriver list) =
+let tile (browsers: IWebDriver list) =
     let h = canopy.screen.screenHeight
     let w = canopy.screen.screenWidth
     let count = browsers.Length
     let maxWidth = w / count
 
-    let rec setSize (browsers : IWebDriver list) c =
+    let rec setSize (browsers: IWebDriver list) c =
         match browsers with
         | [] -> ()
         | b :: tail ->
-            b.Manage().Window.Size <- new System.Drawing.Size(maxWidth,h)
-            b.Manage().Window.Position <- new System.Drawing.Point((maxWidth * c),0)
+            b.Manage().Window.Size <- System.Drawing.Size(maxWidth, h)
+            b.Manage().Window.Position <- System.Drawing.Point((maxWidth * c), 0)
             setSize tail (c + 1)
 
     setSize browsers 0
 
 (* documented/actions *)
-let positionBrowser left top width height (browser : IWebDriver) =
+let positionBrowser left top width height (browser: IWebDriver) =
     let h = canopy.screen.screenHeight
     let w = canopy.screen.screenWidth
 
     let x = left * w / 100
     let y = top * h / 100
-    let bw = width * w /100
+    let bw = width * w / 100
     let bh = height * h / 100
 
-    browser.Manage().Window.Size <- new System.Drawing.Size(bw, bh)
-    browser.Manage().Window.Position <- new System.Drawing.Point(x, y)
+    browser.Manage().Window.Size <- System.Drawing.Size(bw, bh)
+    browser.Manage().Window.Position <- System.Drawing.Point(x, y)
 
 
-let private innerSize (browser : IWebDriver) =
+let private innerSize (browser: IWebDriver) =
     let jsBrowser = browser :?> IJavaScriptExecutor
     let innerWidth = System.Int32.Parse(jsBrowser.ExecuteScript("return window.innerWidth").ToString())
     let innerHeight = System.Int32.Parse(jsBrowser.ExecuteScript("return window.innerHeight").ToString())
     innerWidth, innerHeight
 
 (* documented/actions *)
-let resize size (browser : IWebDriver) =
-    let width,height = size
+let resize size (browser: IWebDriver) =
+    let width, height = size
     let innerWidth, innerHeight = innerSize browser
     let newWidth = browser.Manage().Window.Size.Width - innerWidth + width
     let newHeight = browser.Manage().Window.Size.Height - innerHeight + height
@@ -955,45 +1150,50 @@ let quit browser =
     | _ -> ()
 
 (* documented/actions *)
-let currentUrl (browser : IWebDriver) = browser.Url
+let currentUrl (browser: IWebDriver) = browser.Url
 
 (* documented/assertions *)
-let onn (u: string) (browser : IWebDriver) =
-    let urlPath (u : string) =
-        let url = match u with
-                  | x when x.StartsWith("http") -> u  //leave absolute urls alone
-                  | _ -> "http://host/" + u.Trim('/') //ensure valid uri
-        let uriBuilder = new System.UriBuilder(url)
+let onn (u: string) (browser: IWebDriver) =
+    let urlPath (u: string) =
+        let url =
+            match u with
+            | x when x.StartsWith("http") -> u //leave absolute urls alone
+            | _ -> "http://host/" + u.Trim('/') //ensure valid uri
+
+        let uriBuilder = System.UriBuilder(url)
         uriBuilder.Path.TrimEnd('/') //get the path part removing trailing slashes
-    wait pageTimeout (fun _ -> if browser.Url = u then true else urlPath(browser.Url) = urlPath(u))
+    wait pageTimeout (fun _ ->
+        if browser.Url = u then true
+        else urlPath (browser.Url) = urlPath (u))
 
 (* documented/assertions *)
-let on (u: string) (browser : IWebDriver) =
+let on (u: string) (browser: IWebDriver) =
     try
         onn u browser
-    with
-        | ex -> if browser.Url.Contains(u) = false then raise (CanopyOnException(sprintf "on check failed, expected expression '%s' got %s" u browser.Url))
+    with ex ->
+        if not (browser.Url.Contains(u)) then
+            raise (CanopyOnException(sprintf "on check failed, expected expression '%s' got %s" u browser.Url))
 
 (* documented/actions *)
-let ( !^ ) (u : string) (browser : IWebDriver) =
-    if browser = null then
+let (!^) (u: string) (browser: IWebDriver) =
+    if isNull browser then
         raise (CanopyOnException "Can't navigate to the given url since the browser is not initialized.")
     browser.Navigate().GoToUrl(u)
 
 (* documented/actions *)
-let url u = !^ u
+let url u = !^u
 
 (* documented/actions *)
-let title (browser : IWebDriver) = browser.Title
+let title (browser: IWebDriver) = browser.Title
 
 (* documented/actions *)
-let reload browser = 
-  let url' = currentUrl browser 
-  url url' browser
+let reload browser =
+    let url' = currentUrl browser
+    url url' browser
 
 type Navigate =
-  | Back
-  | Forward
+    | Back
+    | Forward
 
 (* documented/actions *)
 let back = Back
@@ -1001,30 +1201,31 @@ let back = Back
 let forward = Forward
 
 (* documented/actions *)
-let navigate (browser : IWebDriver) direction = 
-  match direction with
-  | Back -> browser.Navigate().Back()
-  | Forward -> browser.Navigate().Forward()
+let navigate (browser: IWebDriver) direction =
+    match direction with
+    | Back -> browser.Navigate().Back()
+    | Forward -> browser.Navigate().Forward()
 
 (* documented/actions *)
 let addFinder finder browser =
     let currentFinders = configuredFinders
-    configuredFinders <- (fun cssSelector browser f ->
-        currentFinders cssSelector browser f
-        |> Seq.append (seq { yield finder cssSelector browser f }))
+    configuredFinders <-
+        (fun cssSelector browser f ->
+        currentFinders cssSelector browser f |> Seq.append (seq { yield finder cssSelector browser f }))
 
 //hints
 let private addHintFinder hints finder = hints |> Seq.append (seq { yield finder })
+
 (* DONT/documented/actions *)
 let addSelector finder hintType selector =
     //gaurd against adding same hintType multipe times and increase size of finder seq
     if not <| (hints.ContainsKey(selector) && addedHints.[selector] |> List.exists (fun hint -> hint = hintType)) then
         if hints.ContainsKey(selector) then
             hints.[selector] <- addHintFinder hints.[selector] finder
-            addedHints.[selector] <- [hintType] @ addedHints.[selector]
+            addedHints.[selector] <- [ hintType ] @ addedHints.[selector]
         else
             hints.[selector] <- seq { yield finder }
-            addedHints.[selector] <- [hintType]
+            addedHints.[selector] <- [ hintType ]
     selector
 
 (* documented/actions *)
@@ -1041,9 +1242,8 @@ let text = addSelector findByText "text"
 let value = addSelector findByValue "value"
 
 let skip message browser =
-  describe (sprintf "Skipped: %s" message) browser
-  raise <| CanopySkipTestException()
+    describe (sprintf "Skipped: %s" message) browser
+    raise <| CanopySkipTestException()
 
 (* documented/actions *)
-let waitForElement cssSelector browser =
-    waitFor (fun _ -> someElement cssSelector browser |> Option.isSome)
+let waitForElement cssSelector browser = waitFor (fun _ -> someElement cssSelector browser |> Option.isSome)

--- a/src/canopy/configuration.fs
+++ b/src/canopy/configuration.fs
@@ -69,7 +69,7 @@ let mutable failIfAnyWipTests = false
 (* documented/configuration *)
 let mutable runFailedContextsFirst = false
 (* documented/configuration *)
-let mutable reporter : IReporter = new ConsoleReporter() :> IReporter
+let mutable reporter : IReporter = ConsoleReporter() :> IReporter
 (* documented/configuration *)
 let mutable disableSuggestOtherSelectors = false
 (* documented/configuration *)
@@ -94,6 +94,10 @@ let mutable skipRemainingTestsInContextOnFailure = false
 let mutable failureMessagesThatShoulBeTreatedAsSkip : string list = []
 (* documented/configuration *)
 let mutable driverHostName = "127.0.0.1"
+(* documented/configuration *)
+let mutable webdriverPort: int option = None
+(* documented/configuration *)
+let mutable acceptInsecureSslCerts = true
 
 //do not touch
 let mutable wipTest = false

--- a/src/canopy/configuration.fs
+++ b/src/canopy/configuration.fs
@@ -69,7 +69,7 @@ let mutable failIfAnyWipTests = false
 (* documented/configuration *)
 let mutable runFailedContextsFirst = false
 (* documented/configuration *)
-let mutable reporter : IReporter = ConsoleReporter() :> IReporter
+let mutable reporter : IReporter = new ConsoleReporter() :> IReporter
 (* documented/configuration *)
 let mutable disableSuggestOtherSelectors = false
 (* documented/configuration *)

--- a/src/canopy/reporters.fs
+++ b/src/canopy/reporters.fs
@@ -96,7 +96,7 @@ type TeamCityReporter(?logImagesToConsole: bool) =
 
     let flowId = System.Guid.NewGuid().ToString()
 
-    let consoleReporter : IReporter = new ConsoleReporter() :> IReporter
+    let consoleReporter : IReporter = ConsoleReporter() :> IReporter
     let tcFriendlyMessage (message : string) =
         let message = message.Replace("|", "||")
         let message = message.Replace("'", "|'")
@@ -164,9 +164,9 @@ type LiveHtmlReporter(browser : BrowserStartMode, driverPath : string, ?driverHo
     let pinBrowserRight = defaultArg pinBrowserRight0 true
     let hideCommandPromptWindow = defaultArg hideCommandPromptWindow0 false
     let driverHostName = defaultArg driverHostName0 "127.0.0.1"
-    let consoleReporter : IReporter = new ConsoleReporter() :> IReporter
-    
-    let chromeDriverService dir = 
+    let consoleReporter : IReporter = ConsoleReporter() :> IReporter
+
+    let chromeDriverService dir =
         let service = Chrome.ChromeDriverService.CreateDefaultService(dir);
         service.HostName <- driverHostName
         service.HideCommandPromptWindow <- hideCommandPromptWindow;
@@ -176,7 +176,7 @@ type LiveHtmlReporter(browser : BrowserStartMode, driverPath : string, ?driverHo
         let options = Chrome.ChromeOptions()
         options.AddArgument("--user-agent=" + userAgent)
         new Chrome.ChromeDriver(chromeDriverService dir, options) :> IWebDriver
-        
+
     let _browser =
         //copy pasta!
         match browser with
@@ -188,9 +188,9 @@ type LiveHtmlReporter(browser : BrowserStartMode, driverPath : string, ?driverHo
             new Chrome.ChromeDriver(chromeDriverService driverPath, options) :> IWebDriver
         | ChromeWithOptions options ->
             new Chrome.ChromeDriver(chromeDriverService driverPath, options) :> IWebDriver
-        | ChromeWithUserAgent userAgent -> 
+        | ChromeWithUserAgent userAgent ->
             chromeWithUserAgent driverPath userAgent
-        | ChromeWithOptionsAndTimeSpan(options, timeSpan) -> 
+        | ChromeWithOptionsAndTimeSpan(options, timeSpan) ->
             new Chrome.ChromeDriver(chromeDriverService driverPath, options, timeSpan) :> IWebDriver
         | ChromeHeadless ->
             let options = Chrome.ChromeOptions()
@@ -203,18 +203,18 @@ type LiveHtmlReporter(browser : BrowserStartMode, driverPath : string, ?driverHo
             let options = Chrome.ChromeOptions()
             options.AddArgument("--disable-extensions")
             options.AddArgument("disable-infobars")
-            options.AddArgument("test-type") //https://code.google.com/p/chromedriver/issues/detail?id=799            
+            options.AddArgument("test-type") //https://code.google.com/p/chromedriver/issues/detail?id=799
             new Chrome.ChromeDriver(chromeDriverService driverPath, options) :> IWebDriver
         | ChromiumWithOptions options ->
             new Chrome.ChromeDriver(chromeDriverService driverPath, options) :> IWebDriver
-        | Remote(url, capabilities) -> new Remote.RemoteWebDriver(new Uri(url), capabilities) :> IWebDriver
+        | Remote(url, capabilities) -> new Remote.RemoteWebDriver(Uri(url), capabilities) :> IWebDriver
         | _ ->  failwith (sprintf "%A browser type not supported in reporter, please file an issue if you think this is incorrect" browser)
 
     let pin () =
         let (w, h) = canopy.screen.getPrimaryScreenResolution ()
         let maxWidth = w / 2
-        _browser.Manage().Window.Size <- new System.Drawing.Size(maxWidth,h)
-        _browser.Manage().Window.Position <- new System.Drawing.Point((maxWidth * 0),0)
+        _browser.Manage().Window.Size <- System.Drawing.Size(maxWidth,h)
+        _browser.Manage().Window.Position <- System.Drawing.Point((maxWidth * 0),0)
 
     let tryPin() =
         if pinBrowserRight then do pin()
@@ -228,7 +228,7 @@ type LiveHtmlReporter(browser : BrowserStartMode, driverPath : string, ?driverHo
     let testStopWatch = System.Diagnostics.Stopwatch()
     let contextStopWatch = System.Diagnostics.Stopwatch()
     let jsEncode value = System.Web.HttpUtility.JavaScriptStringEncode(value)
-    
+
     new (browser : BrowserStartMode, driverPath : string) = LiveHtmlReporter(browser, driverPath, "127.0.0.1", false, true)
 
     member this.browser
@@ -348,7 +348,7 @@ type LiveHtmlReporter(browser : BrowserStartMode, driverPath : string, ?driverHo
         member this.quit () =
           match this.reportPath with
             | Some(path) ->
-              let reportFileInfo = new IO.FileInfo(path)
+              let reportFileInfo = IO.FileInfo(path)
               this.saveReportHtml reportFileInfo.Directory.FullName reportFileInfo.Name
             | None -> consoleReporter.write "Not saving report"
 
@@ -377,7 +377,7 @@ type LiveHtmlReporter(browser : BrowserStartMode, driverPath : string, ?driverHo
 
 type JUnitReporter(resultFilePath:string) =
 
-    let consoleReporter : IReporter = new ConsoleReporter() :> IReporter
+    let consoleReporter : IReporter = ConsoleReporter() :> IReporter
 
     let testStopWatch = System.Diagnostics.Stopwatch()
     let testTimes = ResizeArray<string * float>()
@@ -423,7 +423,7 @@ type JUnitReporter(resultFilePath:string) =
             let resultFile = System.IO.FileInfo(resultFilePath)
             resultFile.Directory.Create()
             consoleReporter.write <| sprintf "Saving results to %s" resultFilePath
-            let enc = new System.Text.UTF8Encoding(false)
+            let enc = System.Text.UTF8Encoding(false)
             let bytes = enc.GetBytes xml
             use fs = new System.IO.FileStream(resultFilePath, System.IO.FileMode.OpenOrCreate)
             fs.Write(bytes, 0, bytes.Length)

--- a/src/canopy/reporters.fs
+++ b/src/canopy/reporters.fs
@@ -96,7 +96,7 @@ type TeamCityReporter(?logImagesToConsole: bool) =
 
     let flowId = System.Guid.NewGuid().ToString()
 
-    let consoleReporter : IReporter = ConsoleReporter() :> IReporter
+    let consoleReporter : IReporter = new ConsoleReporter() :> IReporter
     let tcFriendlyMessage (message : string) =
         let message = message.Replace("|", "||")
         let message = message.Replace("'", "|'")
@@ -164,9 +164,9 @@ type LiveHtmlReporter(browser : BrowserStartMode, driverPath : string, ?driverHo
     let pinBrowserRight = defaultArg pinBrowserRight0 true
     let hideCommandPromptWindow = defaultArg hideCommandPromptWindow0 false
     let driverHostName = defaultArg driverHostName0 "127.0.0.1"
-    let consoleReporter : IReporter = ConsoleReporter() :> IReporter
-
-    let chromeDriverService dir =
+    let consoleReporter : IReporter = new ConsoleReporter() :> IReporter
+    
+    let chromeDriverService dir = 
         let service = Chrome.ChromeDriverService.CreateDefaultService(dir);
         service.HostName <- driverHostName
         service.HideCommandPromptWindow <- hideCommandPromptWindow;
@@ -176,7 +176,7 @@ type LiveHtmlReporter(browser : BrowserStartMode, driverPath : string, ?driverHo
         let options = Chrome.ChromeOptions()
         options.AddArgument("--user-agent=" + userAgent)
         new Chrome.ChromeDriver(chromeDriverService dir, options) :> IWebDriver
-
+        
     let _browser =
         //copy pasta!
         match browser with
@@ -188,9 +188,9 @@ type LiveHtmlReporter(browser : BrowserStartMode, driverPath : string, ?driverHo
             new Chrome.ChromeDriver(chromeDriverService driverPath, options) :> IWebDriver
         | ChromeWithOptions options ->
             new Chrome.ChromeDriver(chromeDriverService driverPath, options) :> IWebDriver
-        | ChromeWithUserAgent userAgent ->
+        | ChromeWithUserAgent userAgent -> 
             chromeWithUserAgent driverPath userAgent
-        | ChromeWithOptionsAndTimeSpan(options, timeSpan) ->
+        | ChromeWithOptionsAndTimeSpan(options, timeSpan) -> 
             new Chrome.ChromeDriver(chromeDriverService driverPath, options, timeSpan) :> IWebDriver
         | ChromeHeadless ->
             let options = Chrome.ChromeOptions()
@@ -203,18 +203,18 @@ type LiveHtmlReporter(browser : BrowserStartMode, driverPath : string, ?driverHo
             let options = Chrome.ChromeOptions()
             options.AddArgument("--disable-extensions")
             options.AddArgument("disable-infobars")
-            options.AddArgument("test-type") //https://code.google.com/p/chromedriver/issues/detail?id=799
+            options.AddArgument("test-type") //https://code.google.com/p/chromedriver/issues/detail?id=799            
             new Chrome.ChromeDriver(chromeDriverService driverPath, options) :> IWebDriver
         | ChromiumWithOptions options ->
             new Chrome.ChromeDriver(chromeDriverService driverPath, options) :> IWebDriver
-        | Remote(url, capabilities) -> new Remote.RemoteWebDriver(Uri(url), capabilities) :> IWebDriver
+        | Remote(url, capabilities) -> new Remote.RemoteWebDriver(new Uri(url), capabilities) :> IWebDriver
         | _ ->  failwith (sprintf "%A browser type not supported in reporter, please file an issue if you think this is incorrect" browser)
 
     let pin () =
         let (w, h) = canopy.screen.getPrimaryScreenResolution ()
         let maxWidth = w / 2
-        _browser.Manage().Window.Size <- System.Drawing.Size(maxWidth,h)
-        _browser.Manage().Window.Position <- System.Drawing.Point((maxWidth * 0),0)
+        _browser.Manage().Window.Size <- new System.Drawing.Size(maxWidth,h)
+        _browser.Manage().Window.Position <- new System.Drawing.Point((maxWidth * 0),0)
 
     let tryPin() =
         if pinBrowserRight then do pin()
@@ -228,7 +228,7 @@ type LiveHtmlReporter(browser : BrowserStartMode, driverPath : string, ?driverHo
     let testStopWatch = System.Diagnostics.Stopwatch()
     let contextStopWatch = System.Diagnostics.Stopwatch()
     let jsEncode value = System.Web.HttpUtility.JavaScriptStringEncode(value)
-
+    
     new (browser : BrowserStartMode, driverPath : string) = LiveHtmlReporter(browser, driverPath, "127.0.0.1", false, true)
 
     member this.browser
@@ -348,7 +348,7 @@ type LiveHtmlReporter(browser : BrowserStartMode, driverPath : string, ?driverHo
         member this.quit () =
           match this.reportPath with
             | Some(path) ->
-              let reportFileInfo = IO.FileInfo(path)
+              let reportFileInfo = new IO.FileInfo(path)
               this.saveReportHtml reportFileInfo.Directory.FullName reportFileInfo.Name
             | None -> consoleReporter.write "Not saving report"
 
@@ -377,7 +377,7 @@ type LiveHtmlReporter(browser : BrowserStartMode, driverPath : string, ?driverHo
 
 type JUnitReporter(resultFilePath:string) =
 
-    let consoleReporter : IReporter = ConsoleReporter() :> IReporter
+    let consoleReporter : IReporter = new ConsoleReporter() :> IReporter
 
     let testStopWatch = System.Diagnostics.Stopwatch()
     let testTimes = ResizeArray<string * float>()
@@ -423,7 +423,7 @@ type JUnitReporter(resultFilePath:string) =
             let resultFile = System.IO.FileInfo(resultFilePath)
             resultFile.Directory.Create()
             consoleReporter.write <| sprintf "Saving results to %s" resultFilePath
-            let enc = System.Text.UTF8Encoding(false)
+            let enc = new System.Text.UTF8Encoding(false)
             let bytes = enc.GetBytes xml
             use fs = new System.IO.FileStream(resultFilePath, System.IO.FileMode.OpenOrCreate)
             fs.Write(bytes, 0, bytes.Length)


### PR DESCRIPTION
* Added configuration flag to specifiy port number for the WebDriver instance to listen on (instead of the default randomized one). Currently, Chrome-family ONLY!
* Added configuration flag to allow insecure SSL certs to be accepted, as without this, Chrome Headless is all but useless. Currently, Chrome-family ONLY!
* Added documentation of above mentioned changes in correct file.
* A lot of stylistic cleanup, reformatting and reflowing suggested by Fantomas formatter tool.