### PR TITLE
add checkedWrite and a custom operator.

### DIFF
--- a/src/canopy/canopy.fs
+++ b/src/canopy/canopy.fs
@@ -108,6 +108,8 @@ let last cssSelector = last cssSelector browser
 (* documented/actions *)
 let ( << ) item text = write item text browser
 
+let ( <<< ) item text = checkedWrite item text browser
+
 (* documented/actions *)
 let read item = read item browser
 


### PR DESCRIPTION
The Webapplication I need to test uses reactive vars and the regular write operator (using .SendKeys() of selenium) leads to lost input. So when typing a string into an input field, every third character is lost, probably because of the JS processing involved.

I had to create a helper which types and verifies that the input is visible in the field;

This PR is just a quick and dirty implementation of that behavior, if you consider it to be relevant for a larger audience, I'd refactor it.