### PR TITLE
WIP: Fix runFor

### DIFF
--- a/docsSrc/Docs/testing.fsx
+++ b/docsSrc/Docs/testing.fsx
@@ -31,10 +31,21 @@ run()
 (**
 runFor
 ----
-Starts test suite and runs the suite with each of the listed browsers.  Usually at the bottom of your Program.fs
+Starts test suite and runs the suite with each of the listed browsers.
+Usually at the bottom of your Program.fs
+
+Pass a list of browsers start modes. There is no need to start a browser beforehand.
 *)
-//TODO Dotnet doesn't allow vague type definitions
-//runFor [chrome; firefox; ie]
+runFor (BrowserStartModes [chrome; firefox; ie])
+
+(**
+Alternatively, you can pass existing browser instances that are already started.
+*)
+start firefox
+let mainBrowser = browser
+start chrome
+let secondBrowser = browser
+runFor (WebDrivers [ mainBrowser; secondBrowser])
 
 
 (**


### PR DESCRIPTION
Fixes #505 
This is what I had in mind to make `runFor` more reliable. It still clones the suites for each browser so that the context is still specific to the browser, but does not add an extra suite to do the browser switching so that running suites in different order doesn't break it.

## Types of changes

What types of changes does your code introduce to canopy?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

Unfortunately it still doesn't satisfactorily show an error if the browser fails to start.
If an exception occurs when starting a browser, then failSuite is run on all suites for that browser instead of running the tests.

But `failSuite` runs `fail` with `autoFail` set to true, just skipping all the tests and nothing actually fails.
What is the point of `autoFail`? Isn't the whole point of failSuite to report all the tests as failed (it's not skipSuite...) https://github.com/lefthandedgoat/canopy/issues/178?

I'm hesitant to just just remove `autoFail` altogether because I don't understand why it was added.
